### PR TITLE
[refactor] Move benchmarks to internal/bench

### DIFF
--- a/internal/bench/print_bench_test.go
+++ b/internal/bench/print_bench_test.go
@@ -1,7 +1,7 @@
 // (c) 2022 Jacek Olszak
 // This code is licensed under MIT license (see LICENSE for details)
 
-package pi_test
+package bench_test
 
 import (
 	"testing"

--- a/internal/bench/screen_bench_test.go
+++ b/internal/bench/screen_bench_test.go
@@ -1,7 +1,7 @@
 // (c) 2022 Jacek Olszak
 // This code is licensed under MIT license (see LICENSE for details)
 
-package pi_test
+package bench_test
 
 import (
 	"fmt"

--- a/internal/bench/sprite_sheet_bench_test.go
+++ b/internal/bench/sprite_sheet_bench_test.go
@@ -1,7 +1,7 @@
 // (c) 2022 Jacek Olszak
 // This code is licensed under MIT license (see LICENSE for details)
 
-package pi_test
+package bench_test
 
 import (
 	"testing"


### PR DESCRIPTION
Benchmarks are not very useful to end-user. Therefore, should be moved to internal package.