### PR TITLE
[bugfix] Run Draw method at most 30 times per second

### DIFF
--- a/ebitengine.go
+++ b/ebitengine.go
@@ -7,14 +7,18 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
 var gameStoppedErr = errors.New("game stopped")
 
+const tps = 30
+
 func run() error {
-	ebiten.SetMaxTPS(30)
+	ebiten.SetMaxTPS(tps)
+	ebiten.SetScreenClearedEveryFrame(false)
 	ebiten.SetRunnableOnUnfocused(true)
 	ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 	ebiten.SetWindowSize(scrWidth*scale(), scrHeight*scale())
@@ -37,10 +41,14 @@ func scale() int {
 }
 
 type ebitengineGame struct {
-	screenDataRGBA []byte // reused RGBA pixels
+	screenDataRGBA     []byte // reused RGBA pixels
+	screenChanged      bool
+	shouldSkipNextDraw bool
 }
 
 func (e *ebitengineGame) Update() error {
+	updateStartedTime := time.Now()
+
 	updateTime()
 	updateController()
 
@@ -52,15 +60,36 @@ func (e *ebitengineGame) Update() error {
 		return gameStoppedErr
 	}
 
+	// Ebitengine treats Draw differently than π. In π Draw must be executed at most 30 times per second.
+	// That's why π runs Draw() from inside Ebitengine's Update().
+	if Draw != nil {
+		if e.shouldSkipNextDraw {
+			e.shouldSkipNextDraw = false
+			return nil
+		}
+
+		Draw()
+
+		elapsed := time.Since(updateStartedTime)
+		if elapsed.Seconds() > 1/float64(tps) {
+			e.shouldSkipNextDraw = true
+		}
+	}
+
+	e.screenChanged = true
+
 	return nil
 }
 
 func (e *ebitengineGame) Draw(screen *ebiten.Image) {
-	if Draw != nil {
-		Draw()
+	// Ebitengine executes Draw based on display frequency.
+	// But the screen is changed at most 30 times per second.
+	// That's why there is no need to replace pixels more often
+	// than 30 times per second.
+	if e.screenChanged {
+		e.replaceScreenPixels(screen)
+		e.screenChanged = false
 	}
-
-	e.replaceScreenPixels(screen)
 }
 
 func (e *ebitengineGame) replaceScreenPixels(screen *ebiten.Image) {


### PR DESCRIPTION
Draw method must be executed at most 30 times per second. The frequency should not depend on display frequency.