### PR TITLE
Run will not boot when game is already booted

### DIFF
--- a/examples/boot/boot.go
+++ b/examples/boot/boot.go
@@ -1,0 +1,24 @@
+// Example showing how to change screen resolution and run π functions before game loop.
+package main
+
+import (
+	"github.com/elgopher/pi"
+)
+
+func main() {
+	// set screen resolution:
+	pi.ScreenWidth = 44
+	pi.ScreenHeight = 44
+
+	// boot the game with custom screen resolution:
+	pi.BootOrPanic()
+
+	// once boot is executed all drawing functions are available:
+	pi.Color(7)
+	pi.Cursor(0, 18)
+	pi.Print("TINY SCREEN") // print text on the screen before game loop
+
+	// Run the game loop.
+	pi.RunOrPanic()
+	// Update and Draw functions were not set therefore screen will be fixed.
+}

--- a/pi.go
+++ b/pi.go
@@ -64,10 +64,16 @@ var (
 // Run boots the game, opens the window and run the game loop. It must be
 // called from the main thread.
 //
+// Run does not boot the game once the game has been booted. Thanks to this,
+// the user can call Boot directly and draw to the screen
+// before the game loop starts.
+//
 // It returns error when something terrible happened during initialization.
 func Run() error {
-	if err := Boot(); err != nil {
-		return fmt.Errorf("booting game failed: %w", err)
+	if !booted {
+		if err := Boot(); err != nil {
+			return fmt.Errorf("booting game failed: %w", err)
+		}
 	}
 
 	timeStarted = time.Now()
@@ -95,6 +101,8 @@ func Reset() {
 	ScreenHeight = defaultScreenHeight
 	Palette = defaultPalette
 }
+
+var booted bool
 
 // Boot initializes the engine based on user parameters such as ScreenWidth and ScreenHeight.
 // It loads the resources like sprite-sheet.png.
@@ -141,6 +149,8 @@ func Boot() error {
 	PalReset()
 	Color(defaultColor)
 	CursorReset()
+
+	booted = true
 
 	return nil
 }


### PR DESCRIPTION
Run calls Boot() which resets draw state and screen data. This is handy, because user does not have to call Boot() explicitly.

But sometimes user wants to run some code before game loop starts but after boot. This commit changes the behaviour of Run, which will not boot again if the game was booted before.