### PR TITLE
Reset clipping region and cursor on ClsCol

### DIFF
--- a/print_test.go
+++ b/print_test.go
@@ -126,6 +126,7 @@ func TestPrint(t *testing.T) {
 	t.Run("should reset cursor", func(t *testing.T) {
 		tests := map[string]func(){
 			"Cls()":         func() { pi.Cls() },
+			"ClsCol(0)":     func() { pi.ClsCol(0) },
 			"CursorReset()": func() { pi.CursorReset() },
 			"Cursor(0,0)":   func() { pi.Cursor(0, 0) },
 		}

--- a/screen.go
+++ b/screen.go
@@ -47,7 +47,15 @@ func cls() {
 }
 
 // ClsCol cleans the entire screen with specified color. It does not take into account any draw state parameters such as clipping region or camera.
+//
+// ClsCol also resets the cursor used for printing text and resets the clipping region.
 func ClsCol(col byte) {
+	clsCol(col)
+	CursorReset()
+	ClipReset()
+}
+
+func clsCol(col byte) {
 	for i := 0; i < len(lineOfScreenWidth); i++ {
 		lineOfScreenWidth[i] = col
 	}

--- a/screen_test.go
+++ b/screen_test.go
@@ -69,11 +69,15 @@ func TestCls(t *testing.T) {
 		assert.Equal(t, []byte{0, 0, 0, 0}, pi.ScreenData)
 	})
 
+	testCls(t, pi.Cls)
+}
+
+func testCls(t *testing.T, cls func()) {
 	t.Run("should reset clipping region", func(t *testing.T) {
 		pi.BootOrPanic()
 		pi.Clip(1, 2, 3, 4)
 		// when
-		pi.Cls() // clips to 0,0,w,h
+		cls() // clips to 0,0,w,h
 		// then
 		prevX, prevY, prevW, prevH := pi.ClipReset()
 		assert.Zero(t, prevX)
@@ -84,7 +88,7 @@ func TestCls(t *testing.T) {
 }
 
 func TestClsCol(t *testing.T) {
-	t.Run("should clean screen using color 0", func(t *testing.T) {
+	t.Run("should clean screen using color 7", func(t *testing.T) {
 		pi.ScreenWidth = 2
 		pi.ScreenHeight = 2
 		pi.BootOrPanic()
@@ -93,6 +97,10 @@ func TestClsCol(t *testing.T) {
 		pi.ClsCol(7)
 		// then
 		assert.Equal(t, []byte{7, 7, 7, 7}, pi.ScreenData)
+	})
+
+	testCls(t, func() {
+		pi.ClsCol(0)
 	})
 }
 


### PR DESCRIPTION
ClsCol should reset clipping region and cursor position used for printing text.