### PR TITLE
Remove Color and ColorReset functions

### DIFF
--- a/examples/boot/main.go
+++ b/examples/boot/main.go
@@ -14,9 +14,8 @@ func main() {
 	pi.BootOrPanic()
 
 	// once boot is executed all drawing functions are available:
-	pi.Color(7)
 	pi.Cursor(0, 18)
-	pi.Print("TINY SCREEN") // print text on the screen before game loop
+	pi.Print("TINY SCREEN", 7) // print text on the screen before game loop
 
 	// Run the game loop.
 	pi.RunOrPanic()

--- a/examples/controller/main.go
+++ b/examples/controller/main.go
@@ -21,6 +21,8 @@ const (
 	dpadInactive   = 5
 	buttonInactive = 8
 	active         = 14
+
+	yellow = 10
 )
 
 func main() {
@@ -72,8 +74,7 @@ func drawPlayerController(player, x, y int) {
 
 func drawPlayerNumber(x int, y int, player int) {
 	pi.PalReset()
-	pi.Color(10)
 	for i := 0; i <= player; i++ {
-		pi.Pset(x+50-i*2, y+8)
+		pi.Pset(x+50-i*2, y+8, yellow)
 	}
 }

--- a/examples/print/main.go
+++ b/examples/print/main.go
@@ -7,12 +7,10 @@ import (
 
 func main() {
 	pi.Draw = func() {
-		pi.CursorReset()   // set cursor to 0,0
-		pi.Color(9)        // change to yellow
-		pi.Cursor(50, 58)  // set cursor position
-		pi.Print("HELLO,") // print text and go to next line
-		pi.Color(12)
-		pi.Print("GOPHER!")
+		pi.CursorReset()      // set cursor to 0,0
+		pi.Cursor(50, 58)     // set cursor position
+		pi.Print("HELLO,", 9) // print yellow text and go to next line
+		pi.Print("GOPHER!", 12)
 	}
 	pi.RunOrPanic()
 }

--- a/examples/shapes/main.go
+++ b/examples/shapes/main.go
@@ -8,25 +8,22 @@ import (
 func main() {
 	pi.Draw = func() {
 		pi.Cls()
-		pi.Color(7)
 
 		pi.Camera(-5, -5) // move every shape 5 pixels to the right, 5 pixels to the bottom
 
 		// draw a filled square with side length=50
-		pi.RectFill(0, 0, 49, 49) // x0=0, y0=0, x1=49, y1=49 (coords are inclusive)
+		pi.RectFill(0, 0, 49, 49, 7) // x0=0, y0=0, x1=49, y1=49 (coords are inclusive), color 7
 
-		pi.Color(8)
 		// draw a filled rectangle 10x20
-		pi.RectFill(19+10, 15+20, 19, 15)
+		pi.RectFill(19+10, 15+20, 19, 15, 8)
 
-		pi.Color(3)
 		// draw rect without filling. Will be drawn on top of existing pixels
-		pi.Rect(10, 10, 80, 80)
+		pi.Rect(10, 10, 80, 80, 3)
 
 		// draw line from x0,y0 to x1,y1 inclusive
-		pi.Line(10, 10, 80, 80)
+		pi.Line(10, 10, 80, 80, 3)
 
-		pi.Line(80, 10, 10, 80)
+		pi.Line(80, 10, 10, 80, 3)
 	}
 
 	pi.RunOrPanic()

--- a/examples/trigonometry/main.go
+++ b/examples/trigonometry/main.go
@@ -16,8 +16,6 @@ func main() {
 
 	pi.Draw = func() {
 		pi.Cls()
-		pi.Color(1)
-
 		draw(32, 8, pi.Sin)
 		draw(96, 11, pi.Cos)
 
@@ -26,19 +24,17 @@ func main() {
 }
 
 func draw(line int, color byte, f func(x float64) float64) {
-	pi.Color(1)
 	drawHorizontalAxis(line)
 
-	pi.Color(color)
 	for x := 0.0; x < 128; x++ {
 		angle := (x + start) / 128
 		dy := math.Round(f(angle) * 16)
-		pi.Pset(int(x), line+int(dy))
+		pi.Pset(int(x), line+int(dy), color)
 	}
 }
 
 func drawHorizontalAxis(line int) {
 	for x := 0; x < 128; x++ {
-		pi.Pset(x, line)
+		pi.Pset(x, line, 1)
 	}
 }

--- a/internal/bench/print_bench_test.go
+++ b/internal/bench/print_bench_test.go
@@ -13,13 +13,13 @@ func BenchmarkPrint(b *testing.B) {
 	runBenchmarks(b, func(r Resolution) {
 		for j := 0; j < 10; j++ {
 			pi.Cursor(0, 0)
-			pi.Print("Hello")
+			pi.Print("Hello", color)
 		}
 	})
 }
 
 func BenchmarkPrintWithScroll(b *testing.B) {
 	runBenchmarks(b, func(r Resolution) {
-		pi.Print("Hello")
+		pi.Print("Hello", color)
 	})
 }

--- a/internal/bench/screen_bench_test.go
+++ b/internal/bench/screen_bench_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/elgopher/pi"
 )
 
+const color = 7
+
 func BenchmarkCls(b *testing.B) {
 	runBenchmarks(b, func(r Resolution) {
 		pi.Cls()
@@ -18,14 +20,14 @@ func BenchmarkCls(b *testing.B) {
 
 func BenchmarkClsCol(b *testing.B) {
 	runBenchmarks(b, func(r Resolution) {
-		pi.ClsCol(7)
+		pi.ClsCol(color)
 	})
 }
 
 func BenchmarkPset(b *testing.B) {
 	runBenchmarks(b, func(res Resolution) {
 		for i := 0; i < 1000; i++ { // Pset is too fast
-			pi.Pset(2, 2)
+			pi.Pset(2, 2, color)
 		}
 	})
 }

--- a/internal/bench/shape_bench_test.go
+++ b/internal/bench/shape_bench_test.go
@@ -11,35 +11,35 @@ import (
 
 func BenchmarkRectFill(b *testing.B) {
 	runBenchmarks(b, func(r Resolution) {
-		pi.RectFill(0, 0, r.W-1, r.H-1)
+		pi.RectFill(0, 0, r.W-1, r.H-1, color)
 	})
 }
 
 func BenchmarkRect(b *testing.B) {
 	runBenchmarks(b, func(r Resolution) {
-		pi.Rect(0, 0, r.W-1, r.H-1)
+		pi.Rect(0, 0, r.W-1, r.H-1, color)
 	})
 }
 
 func BenchmarkLine(b *testing.B) {
 	b.Run("slope=1", func(b *testing.B) {
 		runBenchmarks(b, func(r Resolution) {
-			pi.Line(0, 0, r.W-1, r.H-1)
+			pi.Line(0, 0, r.W-1, r.H-1, color)
 		})
 	})
 	b.Run("slope>1", func(b *testing.B) {
 		runBenchmarks(b, func(r Resolution) {
-			pi.Line(0, 0, r.W-2, r.H-1)
+			pi.Line(0, 0, r.W-2, r.H-1, color)
 		})
 	})
 	b.Run("vertical", func(b *testing.B) {
 		runBenchmarks(b, func(r Resolution) {
-			pi.Line(0, 0, 0, r.H-1)
+			pi.Line(0, 0, 0, r.H-1, color)
 		})
 	})
 	b.Run("horizontal", func(b *testing.B) {
 		runBenchmarks(b, func(r Resolution) {
-			pi.Line(0, 0, r.W-1, 0)
+			pi.Line(0, 0, r.W-1, 0, color)
 		})
 	})
 }

--- a/internal/bench/sprite_sheet_bench_test.go
+++ b/internal/bench/sprite_sheet_bench_test.go
@@ -12,7 +12,7 @@ import (
 func BenchmarkSset(b *testing.B) {
 	runBenchmarks(b, func(res Resolution) {
 		for i := 0; i < 1000; i++ { // Sset is too fast
-			pi.Sset(2, 2, 7)
+			pi.Sset(2, 2, color)
 		}
 	})
 }

--- a/internal/fuzz/print_test.go
+++ b/internal/fuzz/print_test.go
@@ -15,6 +15,6 @@ func FuzzPrint(f *testing.F) {
 	pi.BootOrPanic()
 	f.Fuzz(func(t *testing.T, x, y int) {
 		pi.Cursor(x, y)
-		pi.Print("A")
+		pi.Print("A", color)
 	})
 }

--- a/internal/fuzz/screen_test.go
+++ b/internal/fuzz/screen_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/elgopher/pi"
 )
 
+const color = 7
+
 func FuzzPset(f *testing.F) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 16
 	pi.BootOrPanic()
 	f.Fuzz(func(t *testing.T, x, y int) {
-		pi.Pset(x, y)
+		pi.Pset(x, y, color)
 	})
 }
 

--- a/internal/fuzz/shape_test.go
+++ b/internal/fuzz/shape_test.go
@@ -14,7 +14,7 @@ func FuzzRect(f *testing.F) {
 	pi.ScreenHeight = 16
 	pi.BootOrPanic()
 	f.Fuzz(func(t *testing.T, x0, y0, x1, y1 int) {
-		pi.Rect(x0, y0, x1, y1)
+		pi.Rect(x0, y0, x1, y1, color)
 	})
 }
 
@@ -23,7 +23,7 @@ func FuzzRectFill(f *testing.F) {
 	pi.ScreenHeight = 16
 	pi.BootOrPanic()
 	f.Fuzz(func(t *testing.T, x0, y0, x1, y1 int) {
-		pi.RectFill(x0, y0, x1, y1)
+		pi.RectFill(x0, y0, x1, y1, color)
 	})
 }
 
@@ -32,6 +32,6 @@ func FuzzLine(f *testing.F) {
 	pi.ScreenHeight = 16
 	pi.BootOrPanic()
 	f.Fuzz(func(t *testing.T, x0, y0, x1, y1 int) {
-		pi.Line(x0, y0, x1, y1)
+		pi.Line(x0, y0, x1, y1, color)
 	})
 }

--- a/pi.go
+++ b/pi.go
@@ -23,7 +23,6 @@ const (
 	defaultSpriteSheetHeight = 128
 	defaultScreenWidth       = 128
 	defaultScreenHeight      = 128
-	defaultColor             = byte(6)
 )
 
 // User parameters. Will be used during Boot (and Run).
@@ -110,7 +109,7 @@ var booted bool
 // If sprite-sheet.png was not found in pi.Resources, then empty sprite-sheet is used with
 // the size of pi.SpriteSheetWidth * pi.SpriteSheetHeight.
 //
-// Boot also resets all draw state information like color, camera position and clipping region.
+// Boot also resets all draw state information like camera position and clipping region.
 //
 // Boot can be run multiple times. This is useful for writing unit tests.
 func Boot() error {
@@ -147,7 +146,6 @@ func Boot() error {
 	CameraReset()
 	PaltReset()
 	PalReset()
-	Color(defaultColor)
 	CursorReset()
 
 	booted = true

--- a/pi_test.go
+++ b/pi_test.go
@@ -8,15 +8,18 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/elgopher/pi"
-	"github.com/elgopher/pi/image"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elgopher/pi"
+	"github.com/elgopher/pi/image"
 )
 
 func TestBoot(t *testing.T) {
+	const color = 7
+
 	invalidSpriteSheetSizes := [...]int{
-		0, 1, 7, 9,
+		0, 1, color, 9,
 	}
 
 	t.Run("should return error if SpriteSheetWidth is not multiplication of 8", func(t *testing.T) {
@@ -110,7 +113,6 @@ func TestBoot(t *testing.T) {
 	t.Run("should reset draw state", func(t *testing.T) {
 		pi.Reset()
 		require.NoError(t, pi.Boot())
-		pi.Color(14)
 		pi.Camera(1, 2)
 		pi.Clip(1, 2, 3, 4)
 		// when
@@ -125,7 +127,6 @@ func TestBoot(t *testing.T) {
 		assert.Zero(t, y)
 		assert.Equal(t, pi.ScreenWidth, w)
 		assert.Equal(t, pi.ScreenHeight, h)
-		assert.Equal(t, byte(6), pi.ColorReset())
 	})
 
 	t.Run("changing the user parameters after Boot should not ends up in a panic", func(t *testing.T) {
@@ -142,15 +143,15 @@ func TestBoot(t *testing.T) {
 		pi.SpriteSheetHeight = 1
 		// then
 		assert.NotPanics(t, func() {
-			pi.Pset(1, 1)
+			pi.Pset(1, 1, color)
 			pi.Pget(1, 1)
-			pi.Sset(1, 1, 7)
+			pi.Sset(1, 1, color)
 			pi.Sget(1, 1)
 			pi.Spr(1, 1, 1)
 			pi.SprSize(1, 1, 1, 1.0, 1.0)
 			pi.SprSizeFlip(1, 1, 1, 1.0, 1.0, true, true)
 			pi.Cls()
-			pi.ClsCol(7)
+			pi.ClsCol(color)
 		})
 	})
 
@@ -165,7 +166,7 @@ func TestBoot(t *testing.T) {
 			pi.Spr(4, 0, 0) // sprite-sheet.png has only 4 sprites (from 0 to 3)
 			pi.SprSize(4, 0, 0, 1.0, 1.0)
 			pi.SprSizeFlip(4, 0, 0, 1.0, 1.0, false, false)
-			pi.Pset(16, 16) // sprite-sheet.png is only 16x16 pixels (0..15)
+			pi.Pset(16, 16, color) // sprite-sheet.png is only 16x16 pixels (0..15)
 			pi.Pget(16, 16)
 		})
 	})

--- a/print.go
+++ b/print.go
@@ -67,7 +67,7 @@ func CursorReset() (prevX, prevY int) {
 }
 
 // Print prints text on the screen. It takes into consideration cursor position,
-// color, clipping region and camera position.
+// clipping region and camera position.
 //
 // After printing all characters Print goes to the next line. When there is no space
 // left on screen the clipping region is scrolled to make room.
@@ -77,7 +77,7 @@ func CursorReset() (prevX, prevY int) {
 // found here: https://github.com/elgopher/pi/blob/master/internal/system-font.png
 //
 // Print returns the right-most x position that occurred while printing.
-func Print(text string) (x int) {
+func Print(text string, color byte) (x int) {
 	if cursor.y > scrHeight-systemFont.Height {
 		lines := systemFont.Height - (scrHeight - cursor.y)
 		scroll(lines)
@@ -85,7 +85,7 @@ func Print(text string) (x int) {
 
 	startingX := cursor.x
 	for _, r := range text {
-		printRune(r)
+		printRune(r, color)
 	}
 
 	x = cursor.x
@@ -119,7 +119,7 @@ func scroll(lines int) {
 	cursor.y -= lines
 }
 
-func printRune(r rune) {
+func printRune(r rune, color byte) {
 	if r > 255 {
 		r = '?'
 	}

--- a/print_test.go
+++ b/print_test.go
@@ -8,14 +8,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/elgopher/pi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elgopher/pi"
 )
 
 func TestPrint(t *testing.T) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 24
+
+	const color = 7
 
 	t.Run("should print chars using color on the top-left corner", func(t *testing.T) {
 		chars := []string{`!`, `A`, `b`, `AB`, `ABCD`}
@@ -23,8 +26,7 @@ func TestPrint(t *testing.T) {
 			t.Run(char, func(t *testing.T) {
 				pi.BootOrPanic()
 				// when
-				pi.Color(7)
-				pi.Print(char)
+				pi.Print(char, color)
 				// then
 				assertScreenEqual(t, "internal/testimage/print/"+char+".png")
 			})
@@ -33,30 +35,26 @@ func TestPrint(t *testing.T) {
 
 	t.Run("should print question mark for characters > 255", func(t *testing.T) {
 		pi.BootOrPanic()
-		pi.Color(7)
-		pi.Print("\u0100")
+		pi.Print("\u0100", color)
 		assertScreenEqual(t, "internal/testimage/print/unknown.png")
 	})
 
 	t.Run("should print special character", func(t *testing.T) {
 		pi.BootOrPanic()
-		pi.Color(7)
-		pi.Print("\u0080")
+		pi.Print("\u0080", color)
 		assertScreenEqual(t, "internal/testimage/print/special.png")
 	})
 
 	t.Run("should print 2 special characters", func(t *testing.T) {
 		pi.BootOrPanic()
-		pi.Color(7)
-		pi.Print("\u0080\u0081")
+		pi.Print("\u0080\u0081", color)
 		assertScreenEqual(t, "internal/testimage/print/special-2chars.png")
 	})
 
 	t.Run("should go to next line", func(t *testing.T) {
 		pi.BootOrPanic()
-		pi.Color(7)
-		pi.Print("0L")
-		pi.Print("1L")
+		pi.Print("0L", color)
+		pi.Print("1L", color)
 		assertScreenEqual(t, "internal/testimage/print/two-lines.png")
 	})
 
@@ -71,10 +69,9 @@ func TestPrint(t *testing.T) {
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
-				pi.Color(7)
 				pi.Cursor(test.x, test.y)
-				pi.Print("0L")
-				pi.Print("1L")
+				pi.Print("0L", color)
+				pi.Print("1L", color)
 				assertScreenEqual(t, test.file)
 			})
 		}
@@ -82,10 +79,9 @@ func TestPrint(t *testing.T) {
 
 	t.Run("should print moved by camera position", func(t *testing.T) {
 		pi.BootOrPanic()
-		pi.Color(7)
 		pi.Camera(-1, -2)
-		pi.Print("0L")
-		pi.Print("1L")
+		pi.Print("0L", color)
+		pi.Print("1L", color)
 		assertScreenEqual(t, "internal/testimage/print/two-lines-at-1.2.png")
 	})
 
@@ -101,11 +97,11 @@ func TestPrint(t *testing.T) {
 			"clip top":                 {x: 0, y: 1, w: 16, h: 16, file: "clip-top.png"},
 			"clip bottom":              {x: 0, y: 0, w: 16, h: 4, file: "clip-bottom.png"},
 			"clip left, cursorX set":   {x: 2, y: 0, w: 16, h: 16, cursorX: 1, file: "clip-left-cursorx.png"},
-			"clip right, cursorX set":  {x: 0, y: 0, w: 7, h: 16, cursorX: 1, file: "clip-right-cursorx.png"},
+			"clip right, cursorX set":  {x: 0, y: 0, w: color, h: 16, cursorX: 1, file: "clip-right-cursorx.png"},
 			"clip top, cursorY set":    {x: 0, y: 2, w: 16, h: 16, cursorY: 1, file: "clip-top-cursory.png"},
 			"clip bottom, cursorY set": {x: 0, y: 0, w: 16, h: 5, cursorY: 1, file: "clip-bottom-cursory.png"},
 			"camerax, clip left":       {x: 2, y: 0, w: 16, h: 16, cameraX: -1, file: "clip-left-cursorx.png"},
-			"camerax, clip right":      {x: 0, y: 0, w: 7, h: 16, cameraX: -1, file: "clip-right-cursorx.png"},
+			"camerax, clip right":      {x: 0, y: 0, w: color, h: 16, cameraX: -1, file: "clip-right-cursorx.png"},
 			"cameray, clip top":        {x: 0, y: 2, w: 16, h: 16, cameraY: -1, file: "clip-top-cursory.png"},
 			"cameray, clip bottom":     {x: 0, y: 0, w: 16, h: 5, cameraY: -1, file: "clip-bottom-cursory.png"},
 		}
@@ -115,9 +111,8 @@ func TestPrint(t *testing.T) {
 				pi.BootOrPanic()
 				pi.Camera(test.cameraX, test.cameraY)
 				pi.Clip(test.x, test.y, test.w, test.h)
-				pi.Color(7)
 				pi.Cursor(test.cursorX, test.cursorY)
-				pi.Print("\u0080")
+				pi.Print("\u0080", color)
 				assertScreenEqual(t, "internal/testimage/print/"+test.file)
 			})
 		}
@@ -133,11 +128,10 @@ func TestPrint(t *testing.T) {
 		for name, function := range tests {
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
-				pi.Color(7)
 				pi.Cursor(20, 20)
 				// when
 				function()
-				pi.Print("\u0080")
+				pi.Print("\u0080", color)
 				// then
 				assertScreenEqual(t, "internal/testimage/print/special.png")
 			})
@@ -186,10 +180,9 @@ func TestPrint(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
 				pi.ClsCol(3)
-				pi.Color(7)
 				pi.Cursor(test.cursorX, test.cursorY)
 				// when
-				pi.Print("\u0080")
+				pi.Print("\u0080", color)
 				// then
 				assertScreenEqual(t, test.expectedFile)
 			})
@@ -232,10 +225,9 @@ func TestPrint(t *testing.T) {
 				pi.BootOrPanic()
 				pi.ScreenData = decodePNG(t, "internal/testimage/print/multicolor.png").Pixels
 				pi.Clip(test.clipX, test.clipY, test.clipW, test.clipH)
-				pi.Color(7)
 				pi.Cursor(0, test.cursorY)
 				// when
-				pi.Print("\u0080")
+				pi.Print("\u0080", color)
 				// then
 				assertScreenEqual(t, test.expectedFile)
 			})
@@ -258,7 +250,7 @@ func TestPrint(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
 				// when
-				x := pi.Print(test.text)
+				x := pi.Print(test.text, color)
 				assert.Equal(t, test.expectedX, x)
 			})
 		}

--- a/screen.go
+++ b/screen.go
@@ -30,7 +30,6 @@ var (
 	lineOfScreenWidth   []byte
 	zeroScreenData      []byte
 	clippingRegion      rect
-	color               = defaultColor // Color is a currently used color in draw state. Used by Pset.
 )
 
 // Cls cleans the entire screen with color 0. It does not take into account any draw state parameters such as clipping region or camera.
@@ -67,29 +66,13 @@ func clsCol(col byte) {
 	}
 }
 
-// Color sets the color used by Pset.
-//
-// Color returns previously used color.
-func Color(col byte) (prevCol byte) {
-	prevCol = color
-	color = col
-	return
-}
-
-// ColorReset resets the color to default value which is 6.
-//
-// ColorReset returns previously used color.
-func ColorReset() (prevCol byte) {
-	return Color(defaultColor)
-}
-
-// Pset sets a pixel color on the screen to Color.
-func Pset(x, y int) {
-	pset(x-camera.x, y-camera.y)
+// Pset sets a pixel color on the screen.
+func Pset(x, y int, color byte) {
+	pset(x-camera.x, y-camera.y, color)
 }
 
 // pset sets a pixel color on the screen **without** taking camera position into account.
-func pset(x, y int) {
+func pset(x, y int, color byte) {
 	if x < clippingRegion.x {
 		return
 	}

--- a/screen_test.go
+++ b/screen_test.go
@@ -12,10 +12,11 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/elgopher/pi"
-	"github.com/elgopher/pi/image"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elgopher/pi"
+	"github.com/elgopher/pi/image"
 )
 
 var (
@@ -24,36 +25,6 @@ var (
 	//go:embed internal/testimage/*
 	images embed.FS
 )
-
-func TestColor(t *testing.T) {
-	t.Run("should return default color", func(t *testing.T) {
-		pi.BootOrPanic()
-		assert.Equal(t, byte(6), pi.Color(2))
-	})
-
-	t.Run("should return previous color", func(t *testing.T) {
-		pi.BootOrPanic()
-		prev := byte(3)
-		pi.Color(prev)
-		assert.Equal(t, prev, pi.Color(4))
-	})
-}
-
-func TestColorReset(t *testing.T) {
-	t.Run("should reset color to default", func(t *testing.T) {
-		pi.BootOrPanic()
-		pi.Color(3)
-		pi.ColorReset()
-		assert.Equal(t, byte(6), pi.Color(5))
-	})
-
-	t.Run("should return previous color", func(t *testing.T) {
-		pi.BootOrPanic()
-		prev := byte(5)
-		pi.Color(prev)
-		assert.Equal(t, prev, pi.ColorReset())
-	})
-}
 
 func TestCls(t *testing.T) {
 	pi.Reset()
@@ -112,8 +83,7 @@ func TestPset(t *testing.T) {
 		pi.ScreenHeight = 2
 		pi.BootOrPanic()
 		// when
-		pi.Color(col)
-		pi.Pset(1, 1)
+		pi.Pset(1, 1, col)
 		// then
 		assert.Equal(t, col, pi.ScreenData[3])
 	})
@@ -135,8 +105,7 @@ func TestPset(t *testing.T) {
 			name := fmt.Sprintf("%+v", coords)
 			t.Run(name, func(t *testing.T) {
 				// when
-				pi.Color(col)
-				pi.Pset(coords.X, coords.Y)
+				pi.Pset(coords.X, coords.Y, col)
 				// then
 				assert.Equal(t, emptyScreen, pi.ScreenData)
 			})
@@ -159,8 +128,7 @@ func TestPset(t *testing.T) {
 				pi.BootOrPanic()
 				pi.Clip(1, 1, 1, 1)
 				// when
-				pi.Color(col)
-				pi.Pset(coords.X, coords.Y)
+				pi.Pset(coords.X, coords.Y, col)
 				// then
 				assert.Equal(t, emptyScreen, pi.ScreenData)
 			})
@@ -183,8 +151,7 @@ func TestPset(t *testing.T) {
 				pi.BootOrPanic()
 				pi.Clip(2, 3, 1, 2)
 				// when
-				pi.Color(col)
-				pi.Pset(coords.X, coords.Y)
+				pi.Pset(coords.X, coords.Y, col)
 				// then
 				assert.Equal(t, emptyScreen, pi.ScreenData)
 			})
@@ -198,8 +165,7 @@ func TestPset(t *testing.T) {
 		pi.BootOrPanic()
 		pi.Clip(2, 3, 1, 1)
 		// when
-		pi.Color(col)
-		pi.Pset(2, 3)
+		pi.Pset(2, 3, col)
 		// then
 		assert.NotEqual(t, emptyScreen, pi.ScreenData)
 	})
@@ -209,9 +175,8 @@ func TestPset(t *testing.T) {
 		pi.ScreenHeight = 2
 		pi.BootOrPanic()
 		pi.Camera(1, 2)
-		pi.Color(8)
 		// when
-		pi.Pset(1, 2)
+		pi.Pset(1, 2, 8)
 		// then
 		expected := make([]byte, 4)
 		expected[0] = 8
@@ -240,10 +205,9 @@ func TestPset(t *testing.T) {
 			name := fmt.Sprintf("%+v", coords)
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
-				pi.Color(col)
 				// when
 				pi.Camera(1, 1)
-				pi.Pset(coords.X, coords.Y)
+				pi.Pset(coords.X, coords.Y, col)
 				// then
 				assert.Equal(t, emptyScreen, pi.ScreenData)
 			})
@@ -254,10 +218,9 @@ func TestPset(t *testing.T) {
 		pi.ScreenWidth = 1
 		pi.ScreenHeight = 1
 		pi.BootOrPanic()
-		pi.Color(1)
 		pi.Pal(1, 2)
 		// when
-		pi.Pset(0, 0)
+		pi.Pset(0, 0, 1)
 		// then
 		assert.Equal(t, []byte{2}, pi.ScreenData)
 	})
@@ -266,11 +229,10 @@ func TestPset(t *testing.T) {
 		pi.ScreenWidth = 1
 		pi.ScreenHeight = 1
 		pi.BootOrPanic()
-		pi.Color(1)
 		pi.Pal(1, 2)
 		pi.PalReset()
 		// when
-		pi.Pset(0, 0)
+		pi.Pset(0, 0, 1)
 		// then
 		assert.Equal(t, []byte{1}, pi.ScreenData)
 	})
@@ -282,8 +244,7 @@ func TestPget(t *testing.T) {
 		pi.ScreenHeight = 2
 		pi.BootOrPanic()
 		col := byte(7)
-		pi.Color(col)
-		pi.Pset(1, 1)
+		pi.Pset(1, 1, col)
 		// expect
 		assert.Equal(t, col, pi.Pget(1, 1))
 	})
@@ -325,7 +286,7 @@ func TestPget(t *testing.T) {
 			name := fmt.Sprintf("%+v", coords)
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
-				pi.Pset(coords.X, coords.Y)
+				pi.Pset(coords.X, coords.Y, 7)
 				pi.Clip(1, 1, 1, 1)
 				// when
 				actual := pi.Pget(coords.X, coords.Y)
@@ -348,7 +309,7 @@ func TestPget(t *testing.T) {
 			name := fmt.Sprintf("%+v", coords)
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
-				pi.Pset(coords.X, coords.Y)
+				pi.Pset(coords.X, coords.Y, 7)
 				pi.Clip(2, 3, 1, 2)
 				// when
 				actual := pi.Pget(coords.X, coords.Y)
@@ -363,8 +324,7 @@ func TestPget(t *testing.T) {
 		pi.ScreenHeight = 8
 		pi.BootOrPanic()
 		col := byte(6)
-		pi.Color(col)
-		pi.Pset(2, 3)
+		pi.Pset(2, 3, col)
 		pi.Clip(2, 3, 1, 1)
 		// when
 		actual := pi.Pget(2, 3)
@@ -377,12 +337,12 @@ func TestPget(t *testing.T) {
 		pi.ScreenHeight = 2
 		pi.BootOrPanic()
 		pi.Camera(1, 2)
-		pi.Color(8)
-		pi.Pset(1, 2)
+		const color byte = 8
+		pi.Pset(1, 2, color)
 		// when
 		actual := pi.Pget(1, 2)
 		// then
-		assert.Equal(t, pi.ColorReset(), actual)
+		assert.Equal(t, color, actual)
 	})
 
 	t.Run("should get color 0 for pixels outside the screen when camera is set", func(t *testing.T) {
@@ -797,8 +757,7 @@ func TestSnap(t *testing.T) {
 		pi.BootOrPanic()
 		original, replacement := byte(1), byte(2)
 		pi.PalDisplay(original, replacement) // replace 1 by 2
-		pi.Color(original)
-		pi.Pset(0, 0)
+		pi.Pset(0, 0, original)
 		screenshot, err := pi.Snap()
 		// then
 		require.NoError(t, err)

--- a/shape.go
+++ b/shape.go
@@ -7,9 +7,8 @@ import "math"
 
 // RectFill draws a filled rectangle between points x0,y0 and x1,y1 (inclusive).
 //
-// RectFill takes into consideration: current color, camera position,
-// clipping region and draw palette.
-func RectFill(x0, y0, x1, y1 int) {
+// RectFill takes into account camera position, clipping region and draw palette.
+func RectFill(x0, y0, x1, y1 int, color byte) {
 	xmin, xmax := x0-camera.x, x1-camera.x
 	if xmin > xmax {
 		xmin, xmax = xmax, xmin
@@ -65,9 +64,8 @@ func RectFill(x0, y0, x1, y1 int) {
 
 // Rect draws a rectangle between points x0,y0 and x1,y1 (inclusive).
 //
-// Rect takes into consideration: current color, camera position,
-// clipping region and draw palette.
-func Rect(x0, y0, x1, y1 int) {
+// Rect takes into account camera position, clipping region and draw palette.
+func Rect(x0, y0, x1, y1 int, color byte) {
 	xmin, xmax := x0-camera.x, x1-camera.x
 	if xmin > xmax {
 		xmin, xmax = xmax, xmin
@@ -141,9 +139,8 @@ func Rect(x0, y0, x1, y1 int) {
 
 // Line draws a line between points x0,y0 and x1,y1 (inclusive).
 //
-// Line takes into account the current color, camera position,
-// clipping region and draw palette.
-func Line(x0, y0, x1, y1 int) {
+// Line takes into account camera position, clipping region and draw palette.
+func Line(x0, y0, x1, y1 int, color byte) {
 	x0 -= camera.x
 	x1 -= camera.x
 	y0 -= camera.y
@@ -152,13 +149,13 @@ func Line(x0, y0, x1, y1 int) {
 	// Bresenham algorithm: https://www.youtube.com/watch?v=IDFB5CDpLDE
 	run := float64(x1 - x0)
 	if run == 0 {
-		verticalLine(x0, y0, y1)
+		verticalLine(x0, y0, y1, color)
 		return
 	}
 
 	rise := float64(y1 - y0)
 	if rise == 0 {
-		horizontalLine(y0, x0, x1)
+		horizontalLine(y0, x0, x1, color)
 		return
 	}
 
@@ -181,7 +178,7 @@ func Line(x0, y0, x1, y1 int) {
 		}
 
 		for x := x0; x <= x1; x++ {
-			pset(x, y)
+			pset(x, y, color)
 
 			offset += delta
 			if offset >= threshold {
@@ -198,7 +195,7 @@ func Line(x0, y0, x1, y1 int) {
 		}
 
 		for y := y0; y <= y1; y++ {
-			pset(x, y)
+			pset(x, y, color)
 
 			offset += delta
 			if offset >= threshold {
@@ -210,7 +207,7 @@ func Line(x0, y0, x1, y1 int) {
 }
 
 // verticalLine draws a vertical line between y0-y1 inclusive
-func verticalLine(x, y0, y1 int) {
+func verticalLine(x, y0, y1 int, color byte) {
 	if y0 > y1 {
 		y0, y1 = y1, y0
 	}
@@ -237,7 +234,7 @@ func verticalLine(x, y0, y1 int) {
 }
 
 // horizontalLine draws a vertical line between x0-x1 inclusive
-func horizontalLine(y, x0, x1 int) {
+func horizontalLine(y, x0, x1 int, color byte) {
 	if y < clippingRegion.y {
 		return
 	}

--- a/shape_test.go
+++ b/shape_test.go
@@ -6,15 +6,16 @@ package pi_test
 import (
 	"testing"
 
-	"github.com/elgopher/pi"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elgopher/pi"
 )
 
 func TestRectFill(t *testing.T) {
 	testRect(t, pi.RectFill, "rectfill")
 }
 
-func testRect(t *testing.T, rect func(x0, y0, x1, y1 int), dir string) {
+func testRect(t *testing.T, rect func(x0, y0, x1, y1 int, color byte), dir string) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 16
 
@@ -59,8 +60,7 @@ func testRect(t *testing.T, rect func(x0, y0, x1, y1 int), dir string) {
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
 				pi.ClsCol(5)
-				pi.Color(test.color)
-				rect(test.x0, test.y0, test.x1, test.y1)
+				rect(test.x0, test.y0, test.x1, test.y1, test.color)
 				assertScreenEqual(t, "internal/testimage/"+dir+"/draw/"+name+".png")
 			})
 		}
@@ -113,8 +113,7 @@ func testRect(t *testing.T, rect func(x0, y0, x1, y1 int), dir string) {
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
 				pi.Clip(test.clipX, test.clipY, test.clipW, test.clipH)
-				pi.Color(white)
-				rect(test.x0, test.y0, test.x1, test.y1)
+				rect(test.x0, test.y0, test.x1, test.y1, white)
 				assertScreenEqual(t, "internal/testimage/"+dir+"/clip/"+name+".png")
 			})
 		}
@@ -162,10 +161,9 @@ func testRect(t *testing.T, rect func(x0, y0, x1, y1 int), dir string) {
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
-				pi.Color(white)
 				// when
 				pi.Clip(test.clipX, test.clipY, test.clipW, test.clipH)
-				rect(test.x0, test.y0, test.x1, test.y1)
+				rect(test.x0, test.y0, test.x1, test.y1, white)
 				// then
 				emptyScreen := make([]byte, len(pi.ScreenData))
 				assert.Equal(t, emptyScreen, pi.ScreenData)
@@ -175,17 +173,15 @@ func testRect(t *testing.T, rect func(x0, y0, x1, y1 int), dir string) {
 
 	t.Run("should move by camera position", func(t *testing.T) {
 		pi.BootOrPanic()
-		pi.Color(white)
 		pi.Camera(-2, -3)
-		rect(0, 1, 2, 4)
+		rect(0, 1, 2, 4, white)
 		assertScreenEqual(t, "internal/testimage/"+dir+"/camera_0,1,2,4.png")
 	})
 
 	t.Run("should replace color from draw palette", func(t *testing.T) {
 		pi.BootOrPanic()
-		pi.Color(white)
 		pi.Pal(white, 3)
-		rect(5, 5, 10, 10)
+		rect(5, 5, 10, 10, white)
 		assertScreenEqual(t, "internal/testimage/"+dir+"/pal_5,5,10,10.png")
 	})
 }
@@ -198,7 +194,6 @@ func TestLine(t *testing.T) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 16
 	const white, red = 7, 8
-	pi.Color(red)
 
 	t.Run("should not draw anything outside clipping region", func(t *testing.T) {
 		tests := map[string]struct {
@@ -306,10 +301,9 @@ func TestLine(t *testing.T) {
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
-				pi.Color(white)
 				// when
 				pi.Clip(test.clipX, test.clipY, test.clipW, test.clipH)
-				pi.Line(test.x0, test.y0, test.x1, test.y1)
+				pi.Line(test.x0, test.y0, test.x1, test.y1, white)
 				// then
 				emptyScreen := make([]byte, len(pi.ScreenData))
 				assert.Equal(t, emptyScreen, pi.ScreenData)
@@ -345,9 +339,8 @@ func TestLine(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
 				pi.ClsCol(5)
-				pi.Color(test.color)
 				// when
-				pi.Line(test.x0, test.y0, test.x1, test.y1)
+				pi.Line(test.x0, test.y0, test.x1, test.y1, test.color)
 				assertScreenEqual(t, "internal/testimage/line/draw/"+name+".png")
 			})
 		}
@@ -413,9 +406,8 @@ func TestLine(t *testing.T) {
 				pi.BootOrPanic()
 				pi.ClsCol(5)
 				pi.Clip(test.clipX, test.clipY, test.clipW, test.clipH)
-				pi.Color(white)
 				// when
-				pi.Line(test.x0, test.y0, test.x1, test.y1)
+				pi.Line(test.x0, test.y0, test.x1, test.y1, white)
 				assertScreenEqual(t, "internal/testimage/line/clip/"+name+".png")
 			})
 		}
@@ -442,11 +434,10 @@ func TestLine(t *testing.T) {
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
-				pi.Color(white)
 				pi.ClsCol(5)
 				pi.Pal(white, red)
 				// when
-				pi.Line(test.x0, test.y0, test.x1, test.y1)
+				pi.Line(test.x0, test.y0, test.x1, test.y1, white)
 				assertScreenEqual(t, "internal/testimage/line/pal/"+name+".png")
 			})
 		}
@@ -473,11 +464,10 @@ func TestLine(t *testing.T) {
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
 				pi.BootOrPanic()
-				pi.Color(red)
 				pi.ClsCol(5)
 				pi.Camera(-1, -2)
 				// when
-				pi.Line(test.x0, test.y0, test.x1, test.y1)
+				pi.Line(test.x0, test.y0, test.x1, test.y1, red)
 				assertScreenEqual(t, "internal/testimage/line/camera/"+name+".png")
 			})
 		}


### PR DESCRIPTION
In order to draw a shape, print text or set a pixel color, game developer has to run two functions: First he has to set a color using pi.Color() and then run a specific drawing function such as pi.Rectfill, pi.Print or pi.Pset. This is unhandy, especially if the color is used only once (Way too many keystrokes needed).

Better solution will be to have the color as a last parameter in all drawing functions. Pico-8 is using such approach. Developer can specify the color for each operation. But there is a catch - specifying color also updates the global color state. So, the next operation will use the new color. This is unexpected (and actually a violation of single responsibility principle).

The idea behind this commit is to get rid of color global state. This will simplify the design and drawing functions will have more obvious behaviour. In the end developer will be less confused.