### PR TITLE
Rename RunOrPanic and BootOrPanic to MustRun and MustBoot

### DIFF
--- a/examples/boot/main.go
+++ b/examples/boot/main.go
@@ -11,13 +11,13 @@ func main() {
 	pi.ScreenHeight = 44
 
 	// boot the game with custom screen resolution:
-	pi.BootOrPanic()
+	pi.MustBoot()
 
 	// once boot is executed all drawing functions are available:
 	pi.Cursor(0, 18)
 	pi.Print("TINY SCREEN", 7) // print text on the screen before game loop
 
 	// Run the game loop.
-	pi.RunOrPanic()
+	pi.MustRun()
 	// Update and Draw functions were not set therefore screen will be fixed.
 }

--- a/examples/controller/main.go
+++ b/examples/controller/main.go
@@ -34,7 +34,7 @@ func main() {
 		drawPlayerController(2, 67, 20)
 		drawPlayerController(3, 67, 70)
 	}
-	pi.RunOrPanic()
+	pi.MustRun()
 }
 
 func drawPlayerController(player, x, y int) {

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -24,5 +24,5 @@ func main() {
 			pi.Spr(i, x, 60+int(y))
 		}
 	}
-	pi.RunOrPanic()
+	pi.MustRun()
 }

--- a/examples/memory/main.go
+++ b/examples/memory/main.go
@@ -16,5 +16,5 @@ func main() {
 		}
 	}
 
-	pi.RunOrPanic()
+	pi.MustRun()
 }

--- a/examples/pal/main.go
+++ b/examples/pal/main.go
@@ -58,5 +58,5 @@ func draw() {
 func main() {
 	pi.Resources = resources
 	pi.Draw = draw
-	pi.RunOrPanic()
+	pi.MustRun()
 }

--- a/examples/print/main.go
+++ b/examples/print/main.go
@@ -12,5 +12,5 @@ func main() {
 		pi.Print("HELLO,", 9) // print yellow text and go to next line
 		pi.Print("GOPHER!", 12)
 	}
-	pi.RunOrPanic()
+	pi.MustRun()
 }

--- a/examples/shapes/main.go
+++ b/examples/shapes/main.go
@@ -89,7 +89,7 @@ func main() {
 		drawMousePointer()
 	}
 
-	pi.RunOrPanic()
+	pi.MustRun()
 }
 
 func drawMousePointer() {

--- a/examples/trigonometry/main.go
+++ b/examples/trigonometry/main.go
@@ -20,7 +20,7 @@ func main() {
 		draw(96, 11, pi.Cos)
 
 	}
-	pi.RunOrPanic()
+	pi.MustRun()
 }
 
 func draw(line int, color byte, f func(x float64) float64) {

--- a/internal/bench/screen_bench_test.go
+++ b/internal/bench/screen_bench_test.go
@@ -139,7 +139,7 @@ func runBenchmarks(b *testing.B, callback func(res Resolution)) {
 		b.Run(resolution.String(), func(b *testing.B) {
 			pi.ScreenWidth = resolution.W
 			pi.ScreenHeight = resolution.H
-			pi.BootOrPanic()
+			pi.MustBoot()
 
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/internal/fuzz/print_test.go
+++ b/internal/fuzz/print_test.go
@@ -14,7 +14,7 @@ import (
 func FuzzPrint(f *testing.F) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 24
-	pi.BootOrPanic()
+	pi.MustBoot()
 	f.Fuzz(func(t *testing.T, x, y int) {
 		pi.Cursor(x, y)
 		pi.Print("A", color)

--- a/internal/fuzz/screen_test.go
+++ b/internal/fuzz/screen_test.go
@@ -16,7 +16,7 @@ const color = 7
 func FuzzPset(f *testing.F) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 16
-	pi.BootOrPanic()
+	pi.MustBoot()
 	f.Fuzz(func(t *testing.T, x, y int) {
 		pi.Pset(x, y, color)
 	})
@@ -25,7 +25,7 @@ func FuzzPset(f *testing.F) {
 func FuzzPget(f *testing.F) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 16
-	pi.BootOrPanic()
+	pi.MustBoot()
 	f.Fuzz(func(t *testing.T, x, y int) {
 		pi.Pget(x, y)
 	})
@@ -34,7 +34,7 @@ func FuzzPget(f *testing.F) {
 func FuzzSprSizeFlip(f *testing.F) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 16
-	pi.BootOrPanic()
+	pi.MustBoot()
 	f.Fuzz(func(t *testing.T, n, x, y int, w, h float64, flipX, flipY bool) {
 		pi.SprSizeFlip(n, x, y, w, h, flipX, flipY)
 	})

--- a/internal/fuzz/shape_test.go
+++ b/internal/fuzz/shape_test.go
@@ -14,7 +14,7 @@ import (
 func FuzzRect(f *testing.F) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 16
-	pi.BootOrPanic()
+	pi.MustBoot()
 	f.Fuzz(func(t *testing.T, x0, y0, x1, y1 int) {
 		pi.Rect(x0, y0, x1, y1, color)
 	})
@@ -23,7 +23,7 @@ func FuzzRect(f *testing.F) {
 func FuzzRectFill(f *testing.F) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 16
-	pi.BootOrPanic()
+	pi.MustBoot()
 	f.Fuzz(func(t *testing.T, x0, y0, x1, y1 int) {
 		pi.RectFill(x0, y0, x1, y1, color)
 	})
@@ -32,7 +32,7 @@ func FuzzRectFill(f *testing.F) {
 func FuzzLine(f *testing.F) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 16
-	pi.BootOrPanic()
+	pi.MustBoot()
 	f.Fuzz(func(t *testing.T, x0, y0, x1, y1 int) {
 		pi.Line(x0, y0, x1, y1, color)
 	})
@@ -41,7 +41,7 @@ func FuzzLine(f *testing.F) {
 func FuzzCirc(f *testing.F) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 16
-	pi.BootOrPanic()
+	pi.MustBoot()
 	f.Fuzz(func(t *testing.T, x, y, r int) {
 		pi.Circ(x, y, r, color)
 	})
@@ -50,7 +50,7 @@ func FuzzCirc(f *testing.F) {
 func FuzzCircFill(f *testing.F) {
 	pi.ScreenWidth = 16
 	pi.ScreenHeight = 16
-	pi.BootOrPanic()
+	pi.MustBoot()
 	f.Fuzz(func(t *testing.T, x, y, r int) {
 		pi.CircFill(x, y, r, color)
 	})

--- a/pi.go
+++ b/pi.go
@@ -80,10 +80,10 @@ func Run() error {
 	return run()
 }
 
-// RunOrPanic does the same as Run, but panics instead of returning an error.
+// MustRun does the same as Run, but panics instead of returning an error.
 //
 // Useful for writing unit tests and quick and dirty prototypes. Do not use on production ;)
-func RunOrPanic() {
+func MustRun() {
 	if err := Run(); err != nil {
 		panic(fmt.Sprintf("Something terrible happened! Pi cannot be run: %v\n", err))
 	}
@@ -175,10 +175,10 @@ func loadResources(resources fs.ReadFileFS) error {
 	return loadSpriteSheet(resources)
 }
 
-// BootOrPanic does the same as Boot, but panics instead of returning an error.
+// MustBoot does the same as Boot, but panics instead of returning an error.
 //
 // Useful for writing unit tests and quick and dirty prototypes. Do not use on production ;)
-func BootOrPanic() {
+func MustBoot() {
 	if err := Boot(); err != nil {
 		panic("init failed " + err.Error())
 	}

--- a/pi_test.go
+++ b/pi_test.go
@@ -135,7 +135,7 @@ func TestBoot(t *testing.T) {
 		pi.ScreenHeight = 8
 		pi.SpriteSheetWidth = 8
 		pi.SpriteSheetHeight = 8
-		pi.BootOrPanic()
+		pi.MustBoot()
 		// when
 		pi.ScreenWidth = 1
 		pi.ScreenHeight = 1
@@ -161,7 +161,7 @@ func TestBoot(t *testing.T) {
 		pi.Resources = fstest.MapFS{
 			"sprite-sheet.png": &fstest.MapFile{Data: spriteSheet16x16},
 		}
-		pi.BootOrPanic()
+		pi.MustBoot()
 		assert.NotPanics(t, func() {
 			pi.Spr(4, 0, 0) // sprite-sheet.png has only 4 sprites (from 0 to 3)
 			pi.SprSize(4, 0, 0, 1.0, 1.0)

--- a/print_test.go
+++ b/print_test.go
@@ -24,7 +24,7 @@ func TestPrint(t *testing.T) {
 		chars := []string{`!`, `A`, `b`, `AB`, `ABCD`}
 		for _, char := range chars {
 			t.Run(char, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				// when
 				pi.Print(char, color)
 				// then
@@ -34,25 +34,25 @@ func TestPrint(t *testing.T) {
 	})
 
 	t.Run("should print question mark for characters > 255", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Print("\u0100", color)
 		assertScreenEqual(t, "internal/testimage/print/unknown.png")
 	})
 
 	t.Run("should print special character", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Print("\u0080", color)
 		assertScreenEqual(t, "internal/testimage/print/special.png")
 	})
 
 	t.Run("should print 2 special characters", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Print("\u0080\u0081", color)
 		assertScreenEqual(t, "internal/testimage/print/special-2chars.png")
 	})
 
 	t.Run("should go to next line", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Print("0L", color)
 		pi.Print("1L", color)
 		assertScreenEqual(t, "internal/testimage/print/two-lines.png")
@@ -68,7 +68,7 @@ func TestPrint(t *testing.T) {
 		}
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.Cursor(test.x, test.y)
 				pi.Print("0L", color)
 				pi.Print("1L", color)
@@ -78,7 +78,7 @@ func TestPrint(t *testing.T) {
 	})
 
 	t.Run("should print moved by camera position", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Camera(-1, -2)
 		pi.Print("0L", color)
 		pi.Print("1L", color)
@@ -108,7 +108,7 @@ func TestPrint(t *testing.T) {
 
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.Camera(test.cameraX, test.cameraY)
 				pi.Clip(test.x, test.y, test.w, test.h)
 				pi.Cursor(test.cursorX, test.cursorY)
@@ -127,7 +127,7 @@ func TestPrint(t *testing.T) {
 		}
 		for name, function := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.Cursor(20, 20)
 				// when
 				function()
@@ -178,7 +178,7 @@ func TestPrint(t *testing.T) {
 		}
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.ClsCol(3)
 				pi.Cursor(test.cursorX, test.cursorY)
 				// when
@@ -222,7 +222,7 @@ func TestPrint(t *testing.T) {
 		}
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.ScreenData = decodePNG(t, "internal/testimage/print/multicolor.png").Pixels
 				pi.Clip(test.clipX, test.clipY, test.clipW, test.clipH)
 				pi.Cursor(0, test.cursorY)
@@ -248,7 +248,7 @@ func TestPrint(t *testing.T) {
 		}
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				// when
 				x := pi.Print(test.text, color)
 				assert.Equal(t, test.expectedX, x)
@@ -268,14 +268,14 @@ func assertScreenEqual(t *testing.T, file string) {
 
 func TestCursor(t *testing.T) {
 	t.Run("should return default cursor position", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		x, y := pi.Cursor(1, 1)
 		assert.Zero(t, x)
 		assert.Zero(t, y)
 	})
 
 	t.Run("should return previous cursor position", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		prevX, prevY := 1, 2
 		pi.Cursor(prevX, prevY)
 		// when
@@ -287,14 +287,14 @@ func TestCursor(t *testing.T) {
 
 func TestCursorReset(t *testing.T) {
 	t.Run("should return default cursor position", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		x, y := pi.CursorReset()
 		assert.Zero(t, x)
 		assert.Zero(t, y)
 	})
 
 	t.Run("should return previous cursor position", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		prevX, prevY := 1, 2
 		pi.Cursor(prevX, prevY)
 		// when

--- a/screen_test.go
+++ b/screen_test.go
@@ -33,7 +33,7 @@ func TestCls(t *testing.T) {
 	pi.ScreenHeight = 2
 
 	t.Run("should clean screen using color 0", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.ScreenData = []byte{1, 2, 3, 4}
 		// when
 		pi.Cls()
@@ -46,7 +46,7 @@ func TestCls(t *testing.T) {
 
 func testCls(t *testing.T, cls func()) {
 	t.Run("should reset clipping region", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Clip(1, 2, 3, 4)
 		// when
 		cls() // clips to 0,0,w,h
@@ -63,7 +63,7 @@ func TestClsCol(t *testing.T) {
 	t.Run("should clean screen using color 7", func(t *testing.T) {
 		pi.ScreenWidth = 2
 		pi.ScreenHeight = 2
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.ScreenData = []byte{1, 2, 3, 4}
 		// when
 		pi.ClsCol(7)
@@ -82,7 +82,7 @@ func TestPset(t *testing.T) {
 	t.Run("should set color of pixel", func(t *testing.T) {
 		pi.ScreenWidth = 2
 		pi.ScreenHeight = 2
-		pi.BootOrPanic()
+		pi.MustBoot()
 		// when
 		pi.Pset(1, 1, col)
 		// then
@@ -92,7 +92,7 @@ func TestPset(t *testing.T) {
 	t.Run("should not set pixel outside the screen", func(t *testing.T) {
 		pi.ScreenWidth = 2
 		pi.ScreenHeight = 2
-		pi.BootOrPanic()
+		pi.MustBoot()
 
 		emptyScreen := make([]byte, len(pi.ScreenData))
 
@@ -126,7 +126,7 @@ func TestPset(t *testing.T) {
 		for _, coords := range tests {
 			name := fmt.Sprintf("%+v", coords)
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.Clip(1, 1, 1, 1)
 				// when
 				pi.Pset(coords.X, coords.Y, col)
@@ -149,7 +149,7 @@ func TestPset(t *testing.T) {
 		for _, coords := range tests {
 			name := fmt.Sprintf("%+v", coords)
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.Clip(2, 3, 1, 2)
 				// when
 				pi.Pset(coords.X, coords.Y, col)
@@ -163,7 +163,7 @@ func TestPset(t *testing.T) {
 		pi.ScreenWidth = 8
 		pi.ScreenHeight = 8
 		emptyScreen := make([]byte, 8*8)
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Clip(2, 3, 1, 1)
 		// when
 		pi.Pset(2, 3, col)
@@ -174,7 +174,7 @@ func TestPset(t *testing.T) {
 	t.Run("should set pixel taking camera position into consideration", func(t *testing.T) {
 		pi.ScreenWidth = 2
 		pi.ScreenHeight = 2
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Camera(1, 2)
 		// when
 		pi.Pset(1, 2, 8)
@@ -205,7 +205,7 @@ func TestPset(t *testing.T) {
 		for _, coords := range tests {
 			name := fmt.Sprintf("%+v", coords)
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				// when
 				pi.Camera(1, 1)
 				pi.Pset(coords.X, coords.Y, col)
@@ -218,7 +218,7 @@ func TestPset(t *testing.T) {
 	t.Run("should draw swapped color", func(t *testing.T) {
 		pi.ScreenWidth = 1
 		pi.ScreenHeight = 1
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Pal(1, 2)
 		// when
 		pi.Pset(0, 0, 1)
@@ -229,7 +229,7 @@ func TestPset(t *testing.T) {
 	t.Run("should draw original color after PalReset", func(t *testing.T) {
 		pi.ScreenWidth = 1
 		pi.ScreenHeight = 1
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Pal(1, 2)
 		pi.PalReset()
 		// when
@@ -243,7 +243,7 @@ func TestPget(t *testing.T) {
 	t.Run("should get color of pixel", func(t *testing.T) {
 		pi.ScreenWidth = 2
 		pi.ScreenHeight = 2
-		pi.BootOrPanic()
+		pi.MustBoot()
 		col := byte(7)
 		pi.Pset(1, 1, col)
 		// expect
@@ -253,7 +253,7 @@ func TestPget(t *testing.T) {
 	t.Run("should get color 0 if outside the screen", func(t *testing.T) {
 		pi.ScreenWidth = 2
 		pi.ScreenHeight = 2
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.ClsCol(7)
 
 		tests := []struct{ X, Y int }{
@@ -286,7 +286,7 @@ func TestPget(t *testing.T) {
 		for _, coords := range tests {
 			name := fmt.Sprintf("%+v", coords)
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.Pset(coords.X, coords.Y, 7)
 				pi.Clip(1, 1, 1, 1)
 				// when
@@ -309,7 +309,7 @@ func TestPget(t *testing.T) {
 		for _, coords := range tests {
 			name := fmt.Sprintf("%+v", coords)
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.Pset(coords.X, coords.Y, 7)
 				pi.Clip(2, 3, 1, 2)
 				// when
@@ -323,7 +323,7 @@ func TestPget(t *testing.T) {
 	t.Run("should get pixel inside the clipping region", func(t *testing.T) {
 		pi.ScreenWidth = 8
 		pi.ScreenHeight = 8
-		pi.BootOrPanic()
+		pi.MustBoot()
 		col := byte(6)
 		pi.Pset(2, 3, col)
 		pi.Clip(2, 3, 1, 1)
@@ -336,7 +336,7 @@ func TestPget(t *testing.T) {
 	t.Run("should get pixel taking camera position into consideration", func(t *testing.T) {
 		pi.ScreenWidth = 2
 		pi.ScreenHeight = 2
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Camera(1, 2)
 		const color byte = 8
 		pi.Pset(1, 2, color)
@@ -366,7 +366,7 @@ func TestPget(t *testing.T) {
 		for _, coords := range tests {
 			name := fmt.Sprintf("%+v", coords)
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.ClsCol(7)
 				pi.Camera(1, 1)
 				// when
@@ -381,7 +381,7 @@ func TestClip(t *testing.T) {
 	t.Run("should return entire screen by default", func(t *testing.T) {
 		pi.ScreenWidth = 8
 		pi.ScreenHeight = 8
-		pi.BootOrPanic()
+		pi.MustBoot()
 		x, y, w, h := pi.Clip(1, 2, 3, 4)
 		assert.Zero(t, x)
 		assert.Zero(t, y)
@@ -392,7 +392,7 @@ func TestClip(t *testing.T) {
 	t.Run("should return previous clipping region", func(t *testing.T) {
 		pi.ScreenWidth = 8
 		pi.ScreenHeight = 8
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Clip(1, 2, 3, 4)
 		x, y, w, h := pi.Clip(5, 6, 7, 8)
 		assert.Equal(t, 1, x)
@@ -414,7 +414,7 @@ func TestClip(t *testing.T) {
 			t.Run(fmt.Sprintf("%+v", given), func(t *testing.T) {
 				pi.ScreenWidth = 8
 				pi.ScreenHeight = 8
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.Clip(given.x, given.y, given.w, given.h)
 				x, y, w, h := pi.ClipReset()
 				assert.Equal(t, expected.x, x)
@@ -428,7 +428,7 @@ func TestClip(t *testing.T) {
 
 func TestClipReset(t *testing.T) {
 	t.Run("should return previous clip", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Clip(1, 2, 3, 4)
 		// when
 		x, y, w, h := pi.ClipReset()
@@ -440,7 +440,7 @@ func TestClipReset(t *testing.T) {
 	})
 
 	t.Run("should reset clip to full screen size", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Clip(1, 2, 3, 4)
 		// when
 		pi.ClipReset()
@@ -455,14 +455,14 @@ func TestClipReset(t *testing.T) {
 
 func TestCamera(t *testing.T) {
 	t.Run("should return initial camera", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		initialX, initialY := pi.Camera(1, 2)
 		assert.Equal(t, 0, initialX)
 		assert.Equal(t, 0, initialY)
 	})
 
 	t.Run("should return previous camera", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Camera(1, 2)
 		x, y := pi.Camera(2, 3)
 		assert.Equal(t, 1, x)
@@ -487,7 +487,7 @@ func testSpr(t *testing.T, spr func(spriteNo int, x int, y int)) {
 				pi.ScreenHeight = 8
 				pi.SpriteSheetWidth = 16
 				pi.SpriteSheetHeight = 16
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.ClsCol(7)
 				snapshot := clone(pi.ScreenData)
 				// when
@@ -596,7 +596,7 @@ func testSpr(t *testing.T, spr func(spriteNo int, x int, y int)) {
 	t.Run("should swap color", func(t *testing.T) {
 		pi.SpriteSheetWidth, pi.SpriteSheetHeight = 8, 8
 		pi.ScreenWidth, pi.ScreenHeight = 8, 8
-		pi.BootOrPanic()
+		pi.MustBoot()
 		const originalColor byte = 7
 		const replacementColor byte = 15
 		pi.Sset(5, 5, originalColor)
@@ -646,7 +646,7 @@ func testSprSize(t *testing.T, sprSize func(spriteNo int, x, y int, w, h float64
 				pi.ScreenHeight = 8
 				pi.SpriteSheetWidth = 16
 				pi.SpriteSheetHeight = 16
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.ClsCol(7)
 				snapshot := clone(pi.ScreenData)
 				// when
@@ -742,7 +742,7 @@ func TestSnap(t *testing.T) {
 
 	t.Run("should take screenshot and store it to temp file", func(t *testing.T) {
 		pi.Reset()
-		pi.BootOrPanic()
+		pi.MustBoot()
 		for i := 0; i < len(pi.ScreenData); i++ {
 			pi.ScreenData[i] = byte(i % 16) // 16 colors by default
 		}
@@ -760,7 +760,7 @@ func TestSnap(t *testing.T) {
 	t.Run("should use display palette", func(t *testing.T) {
 		pi.Reset()
 		pi.ScreenWidth, pi.ScreenHeight = 1, 1
-		pi.BootOrPanic()
+		pi.MustBoot()
 		original, replacement := byte(1), byte(2)
 		pi.PalDisplay(original, replacement) // replace 1 by 2
 		pi.Pset(0, 0, original)
@@ -806,5 +806,5 @@ func boot(screenWidth, screenHeight int, spriteSheet []byte) {
 	pi.Resources = fstest.MapFS{
 		"sprite-sheet.png": &fstest.MapFile{Data: spriteSheet},
 	}
-	pi.BootOrPanic()
+	pi.MustBoot()
 }

--- a/shape_test.go
+++ b/shape_test.go
@@ -58,7 +58,7 @@ func testRect(t *testing.T, rect func(x0, y0, x1, y1 int, color byte), dir strin
 
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.ClsCol(5)
 				rect(test.x0, test.y0, test.x1, test.y1, test.color)
 				assertScreenEqual(t, "internal/testimage/"+dir+"/draw/"+name+".png")
@@ -111,7 +111,7 @@ func testRect(t *testing.T, rect func(x0, y0, x1, y1 int, color byte), dir strin
 
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.Clip(test.clipX, test.clipY, test.clipW, test.clipH)
 				rect(test.x0, test.y0, test.x1, test.y1, white)
 				assertScreenEqual(t, "internal/testimage/"+dir+"/clip/"+name+".png")
@@ -160,7 +160,7 @@ func testRect(t *testing.T, rect func(x0, y0, x1, y1 int, color byte), dir strin
 
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				// when
 				pi.Clip(test.clipX, test.clipY, test.clipW, test.clipH)
 				rect(test.x0, test.y0, test.x1, test.y1, white)
@@ -172,14 +172,14 @@ func testRect(t *testing.T, rect func(x0, y0, x1, y1 int, color byte), dir strin
 	})
 
 	t.Run("should move by camera position", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Camera(-2, -3)
 		rect(0, 1, 2, 4, white)
 		assertScreenEqual(t, "internal/testimage/"+dir+"/camera_0,1,2,4.png")
 	})
 
 	t.Run("should replace color from draw palette", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.Pal(white, 3)
 		rect(5, 5, 10, 10, white)
 		assertScreenEqual(t, "internal/testimage/"+dir+"/pal_5,5,10,10.png")
@@ -300,7 +300,7 @@ func TestLine(t *testing.T) {
 
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				// when
 				pi.Clip(test.clipX, test.clipY, test.clipW, test.clipH)
 				pi.Line(test.x0, test.y0, test.x1, test.y1, white)
@@ -337,7 +337,7 @@ func TestLine(t *testing.T) {
 
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.ClsCol(5)
 				// when
 				pi.Line(test.x0, test.y0, test.x1, test.y1, test.color)
@@ -403,7 +403,7 @@ func TestLine(t *testing.T) {
 
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.ClsCol(5)
 				pi.Clip(test.clipX, test.clipY, test.clipW, test.clipH)
 				// when
@@ -433,7 +433,7 @@ func TestLine(t *testing.T) {
 
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.ClsCol(5)
 				pi.Pal(white, red)
 				// when
@@ -463,7 +463,7 @@ func TestLine(t *testing.T) {
 
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.ClsCol(5)
 				pi.Camera(-1, -2)
 				// when
@@ -502,7 +502,7 @@ func testCirc(t *testing.T, circ func(x, y, r int, color byte), dir string) {
 
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.ClsCol(5)
 				// when
 				circ(test.x, test.y, test.r, test.color)
@@ -512,7 +512,7 @@ func testCirc(t *testing.T, circ func(x, y, r int, color byte), dir string) {
 	})
 
 	t.Run("should use draw palette", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.ClsCol(5)
 		pi.Pal(white, red)
 		// when
@@ -521,7 +521,7 @@ func testCirc(t *testing.T, circ func(x, y, r int, color byte), dir string) {
 	})
 
 	t.Run("should move by camera position", func(t *testing.T) {
-		pi.BootOrPanic()
+		pi.MustBoot()
 		pi.ClsCol(5)
 		pi.Camera(2, 1)
 		// when
@@ -554,7 +554,7 @@ func testCirc(t *testing.T, circ func(x, y, r int, color byte), dir string) {
 
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				pi.BootOrPanic()
+				pi.MustBoot()
 				pi.ClsCol(5)
 				// when
 				pi.Clip(test.clipX, test.clipY, test.clipW, test.clipH)

--- a/sprite_sheet_test.go
+++ b/sprite_sheet_test.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/elgopher/pi"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elgopher/pi"
 )
 
 func TestSset(t *testing.T) {
@@ -19,7 +20,7 @@ func TestSset(t *testing.T) {
 		pi.SpriteSheetWidth = 8
 		pi.SpriteSheetHeight = 8
 		pi.Resources = embed.FS{}
-		pi.BootOrPanic()
+		pi.MustBoot()
 		// when
 		pi.Sset(2, 1, col)
 		// then
@@ -29,7 +30,7 @@ func TestSset(t *testing.T) {
 	t.Run("should not set pixel outside the sprite sheet", func(t *testing.T) {
 		pi.SpriteSheetWidth = 8
 		pi.SpriteSheetHeight = 8
-		pi.BootOrPanic()
+		pi.MustBoot()
 
 		emptySheet := make([]byte, len(pi.SpriteSheetData))
 
@@ -56,7 +57,7 @@ func TestSget(t *testing.T) {
 		pi.SpriteSheetWidth = 8
 		pi.SpriteSheetHeight = 8
 		pi.Resources = embed.FS{}
-		pi.BootOrPanic()
+		pi.MustBoot()
 		col := byte(7)
 		pi.Sset(1, 1, col)
 		// expect
@@ -66,7 +67,7 @@ func TestSget(t *testing.T) {
 	t.Run("should get color 0 if outside the sprite sheet", func(t *testing.T) {
 		pi.SpriteSheetWidth = 8
 		pi.SpriteSheetHeight = 8
-		pi.BootOrPanic()
+		pi.MustBoot()
 		for i := 0; i < len(pi.SpriteSheetData); i++ {
 			pi.SpriteSheetData[i] = 7
 		}


### PR DESCRIPTION
Must prefix is an idiomatic Go - for example regexp package has the MustCompile function. Many 3rd party libraries use similar convention. Additionally, MustRun has lower number of characters than RunOrPanic (which is usually good for public functions).