### PR TITLE
Move State*** functions to new state package

### DIFF
--- a/examples/state/main.go
+++ b/examples/state/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/elgopher/pi"
+	"github.com/elgopher/pi/state"
 )
 
 // Savegame is a struct which will be stored permanently.
@@ -26,15 +26,15 @@ func main() {
 	var lang string
 
 	// start with loading a single value
-	if err = pi.StateLoad("language", &lang); errors.Is(err, pi.ErrStateNotFound) {
+	if err = state.Load("language", &lang); errors.Is(err, state.ErrNotFound) {
 		// language was not found, use default language
 		lang = "EN"
 		// save default language
-		if err = pi.StateSave("language", lang); err != nil {
+		if err = state.Save("language", lang); err != nil {
 			panic(err)
 		}
 	}
-	// there could be some other error returned by StateLoad
+	// there could be some other error returned by Load
 	if err != nil {
 		panic(err)
 	}
@@ -49,26 +49,26 @@ func main() {
 	}
 
 	// Store game state for slot-0.
-	if err = pi.StateSave("slot-0", saveGame); err != nil {
+	if err = state.Save("slot-0", saveGame); err != nil {
 		panic(err)
 	}
 
 	// load existing save game
-	if err = pi.StateLoad("slot-0", &saveGame); err != nil {
+	if err = state.Load("slot-0", &saveGame); err != nil {
 		panic(err)
 	}
 
 	fmt.Printf("%+v\n", saveGame)
 
 	// return all state names
-	names, err := pi.States()
+	names, err := state.All()
 	if err != nil {
 		panic(err)
 	}
 
 	// remove all saved states
 	for _, name := range names {
-		if err = pi.StateDelete(name); err != nil {
+		if err = state.Delete(name); err != nil {
 			panic(err)
 		}
 	}

--- a/state/internal/state.go
+++ b/state/internal/state.go
@@ -1,7 +1,7 @@
 // (c) 2022 Jacek Olszak
 // This code is licensed under MIT license (see LICENSE for details)
 
-package state
+package internal
 
 import "errors"
 

--- a/state/internal/state_fs.go
+++ b/state/internal/state_fs.go
@@ -3,7 +3,7 @@
 
 //go:build !js
 
-package state
+package internal
 
 import (
 	"errors"

--- a/state/internal/state_js.go
+++ b/state/internal/state_js.go
@@ -1,7 +1,7 @@
 // (c) 2022 Jacek Olszak
 // This code is licensed under MIT license (see LICENSE for details)
 
-package state
+package internal
 
 import (
 	"fmt"

--- a/vm/gameloop.go
+++ b/vm/gameloop.go
@@ -1,3 +1,6 @@
+// (c) 2022 Jacek Olszak
+// This code is licensed under MIT license (see LICENSE for details)
+
 package vm
 
 var (


### PR DESCRIPTION
Code for managing state information is big and  imports a lot of dependencies (json and fmt). Most games will not store state, therefore this code should not be place in a core package. This could reduce binary size.
