### PR TITLE
Move Snap() function to new `snap` package

### DIFF
--- a/print_test.go
+++ b/print_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elgopher/pi"
+	"github.com/elgopher/pi/snap"
 	"github.com/elgopher/pi/vm"
 )
 
@@ -141,7 +142,7 @@ func TestPrint(t *testing.T) {
 func assertScreenEqual(t *testing.T, file string) {
 	expected := decodePNG(t, file).Pixels
 	if !assert.Equal(t, expected, vm.ScreenData) {
-		screenshot, err := pi.Snap()
+		screenshot, err := snap.Take()
 		require.NoError(t, err)
 		fmt.Println("Screenshot taken", screenshot)
 	}

--- a/screen.go
+++ b/screen.go
@@ -4,13 +4,6 @@
 package pi
 
 import (
-	"fmt"
-	"image"
-	stdcolor "image/color"
-	"image/png"
-	"os"
-	"runtime"
-
 	"github.com/elgopher/pi/vm"
 )
 
@@ -288,40 +281,4 @@ func init() {
 func PalReset() {
 	vm.DrawPalette = notSwappedPalette
 	vm.DisplayPalette = notSwappedPalette
-}
-
-// Snap takes a screenshot and saves it to temp dir.
-//
-// Snap returns a filename. If something went wrong error is returned.
-func Snap() (string, error) {
-	if runtime.GOOS == "js" {
-		return "", fmt.Errorf("storing files does not work on js")
-	}
-
-	var palette stdcolor.Palette
-	for _, col := range vm.DisplayPalette {
-		rgb := vm.Palette[col]
-		rgba := &stdcolor.NRGBA{R: rgb.R, G: rgb.G, B: rgb.B, A: 255}
-		palette = append(palette, rgba)
-	}
-
-	size := image.Rectangle{Max: image.Point{X: vm.ScreenWidth, Y: vm.ScreenHeight}}
-	img := image.NewPaletted(size, palette)
-
-	copy(img.Pix, vm.ScreenData)
-
-	file, err := os.CreateTemp("", "pi-screenshot")
-	if err != nil {
-		return "", fmt.Errorf("error creating temp file for screenshot: %w", err)
-	}
-
-	if err = png.Encode(file, img); err != nil {
-		return "", fmt.Errorf("error encoding screenshot into PNG file: %w", err)
-	}
-
-	if err = file.Close(); err != nil {
-		return "", fmt.Errorf("error closing file: %w", err)
-	}
-
-	return file.Name(), nil
 }

--- a/screen_test.go
+++ b/screen_test.go
@@ -8,8 +8,6 @@ import (
 	"embed"
 	_ "embed"
 	"fmt"
-	"os"
-	"runtime"
 	"testing"
 	"testing/fstest"
 
@@ -735,45 +733,6 @@ func TestSprSizeFlip(t *testing.T) {
 	})
 }
 
-func TestSnap(t *testing.T) {
-	if runtime.GOOS == "js" {
-		t.Skip("storing files does not work on js")
-		return
-	}
-
-	t.Run("should take screenshot and store it to temp file", func(t *testing.T) {
-		pi.Reset()
-		pi.MustBoot()
-		for i := 0; i < len(vm.ScreenData); i++ {
-			vm.ScreenData[i] = byte(i % 16) // 16 colors by default
-		}
-		// when
-		screenshot, err := pi.Snap()
-		// then
-		require.NoError(t, err)
-		img := decodeScreenshot(t, screenshot)
-		assert.Equal(t, pi.ScreenWidth, img.Width)
-		assert.Equal(t, pi.ScreenHeight, img.Height)
-		assert.Equal(t, vm.ScreenData, img.Pixels)
-		assert.Equal(t, vm.Palette, img.Palette)
-	})
-
-	t.Run("should use display palette", func(t *testing.T) {
-		pi.Reset()
-		pi.ScreenWidth, pi.ScreenHeight = 1, 1
-		pi.MustBoot()
-		original, replacement := byte(1), byte(2)
-		pi.PalDisplay(original, replacement) // replace 1 by 2
-		pi.Pset(0, 0, original)
-		screenshot, err := pi.Snap()
-		// then
-		require.NoError(t, err)
-		img := decodeScreenshot(t, screenshot)
-		assert.Equal(t, vm.Palette[2], img.Palette[1]) // 1 is replaced by 2
-		assert.Equal(t, vm.ScreenData, img.Pixels)
-	})
-}
-
 func clone(s []byte) []byte {
 	cloned := make([]byte, len(s))
 	copy(cloned, s)
@@ -790,14 +749,6 @@ func decodePNG(t *testing.T, file string) image.Image {
 	data, err := image.DecodePNG(bytes.NewReader(payload))
 	require.NoError(t, err)
 	return data
-}
-
-func decodeScreenshot(t *testing.T, screenshot string) image.Image {
-	file, err := os.Open(screenshot)
-	require.NoError(t, err)
-	img, err := image.DecodePNG(file)
-	require.NoError(t, err)
-	return img
 }
 
 func boot(screenWidth, screenHeight int, spriteSheet []byte) {

--- a/snap/snap.go
+++ b/snap/snap.go
@@ -1,0 +1,52 @@
+// (c) 2022 Jacek Olszak
+// This code is licensed under MIT license (see LICENSE for details)
+
+// Package snap provides functions for taking screenshots.
+package snap
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"runtime"
+
+	"github.com/elgopher/pi/vm"
+)
+
+// Take takes a screenshot and saves it to temp dir.
+//
+// Take returns a filename. If something went wrong error is returned.
+func Take() (string, error) {
+	if runtime.GOOS == "js" {
+		return "", fmt.Errorf("storing files does not work on js")
+	}
+
+	var palette color.Palette
+	for _, col := range vm.DisplayPalette {
+		rgb := vm.Palette[col]
+		rgba := &color.NRGBA{R: rgb.R, G: rgb.G, B: rgb.B, A: 255}
+		palette = append(palette, rgba)
+	}
+
+	size := image.Rectangle{Max: image.Point{X: vm.ScreenWidth, Y: vm.ScreenHeight}}
+	img := image.NewPaletted(size, palette)
+
+	copy(img.Pix, vm.ScreenData)
+
+	file, err := os.CreateTemp("", "pi-screenshot")
+	if err != nil {
+		return "", fmt.Errorf("error creating temp file for screenshot: %w", err)
+	}
+
+	if err = png.Encode(file, img); err != nil {
+		return "", fmt.Errorf("error encoding screenshot into PNG file: %w", err)
+	}
+
+	if err = file.Close(); err != nil {
+		return "", fmt.Errorf("error closing file: %w", err)
+	}
+
+	return file.Name(), nil
+}

--- a/snap/snap_test.go
+++ b/snap/snap_test.go
@@ -1,0 +1,65 @@
+// (c) 2022 Jacek Olszak
+// This code is licensed under MIT license (see LICENSE for details)
+
+package snap_test
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elgopher/pi"
+	"github.com/elgopher/pi/image"
+	"github.com/elgopher/pi/snap"
+	"github.com/elgopher/pi/vm"
+)
+
+func TestSnap(t *testing.T) {
+	if runtime.GOOS == "js" {
+		t.Skip("storing files does not work on js")
+		return
+	}
+
+	t.Run("should take screenshot and store it to temp file", func(t *testing.T) {
+		pi.Reset()
+		pi.MustBoot()
+		for i := 0; i < len(vm.ScreenData); i++ {
+			vm.ScreenData[i] = byte(i % 16) // 16 colors by default
+		}
+		// when
+		screenshot, err := snap.Take()
+		// then
+		require.NoError(t, err)
+		img := decodeScreenshot(t, screenshot)
+		assert.Equal(t, pi.ScreenWidth, img.Width)
+		assert.Equal(t, pi.ScreenHeight, img.Height)
+		assert.Equal(t, vm.ScreenData, img.Pixels)
+		assert.Equal(t, vm.Palette, img.Palette)
+	})
+
+	t.Run("should use display palette", func(t *testing.T) {
+		pi.Reset()
+		pi.ScreenWidth, pi.ScreenHeight = 1, 1
+		pi.MustBoot()
+		original, replacement := byte(1), byte(2)
+		pi.PalDisplay(original, replacement) // replace 1 by 2
+		pi.Pset(0, 0, original)
+		screenshot, err := snap.Take()
+		// then
+		require.NoError(t, err)
+		img := decodeScreenshot(t, screenshot)
+		assert.Equal(t, vm.Palette[2], img.Palette[1]) // 1 is replaced by 2
+		assert.Equal(t, vm.ScreenData, img.Pixels)
+	})
+}
+
+func decodeScreenshot(t *testing.T, screenshot string) image.Image {
+	file, err := os.Open(screenshot)
+	require.NoError(t, err)
+	img, err := image.DecodePNG(file)
+	require.NoError(t, err)
+	return img
+}

--- a/state/state.go
+++ b/state/state.go
@@ -1,6 +1,7 @@
 // (c) 2022 Jacek Olszak
 // This code is licensed under MIT license (see LICENSE for details)
 
+// Package state provides functions for managing persistent game data.
 package state
 
 import (


### PR DESCRIPTION
Rename to snap.Take().

This function imports a lot of dependencies (such as os and image/*). Most games will not use it, so the function should not be a part of core pi package.