### PR TITLE
Remove fmt dependency from vm package

### DIFF
--- a/vm/palette.go
+++ b/vm/palette.go
@@ -3,10 +3,6 @@
 
 package vm
 
-import (
-	"fmt"
-)
-
 var (
 	// Palette has all colors available in the game. Up to 256.
 	// Palette is taken from loaded sprite sheet (which must be
@@ -26,6 +22,23 @@ var (
 type RGB struct{ R, G, B byte }
 
 func (r RGB) String() string {
-	var rgb = int(r.R)<<16 + int(r.G)<<8 + int(r.B)
-	return fmt.Sprintf("#%.6x", rgb) // avoid dependency on fmt inside the entire package
+	out := make([]byte, 7)
+	out[0] = '#'
+	writeByteAsHex(r.R, out[1:3])
+	writeByteAsHex(r.G, out[3:5])
+	writeByteAsHex(r.B, out[5:7])
+	return string(out)
+}
+
+func writeByteAsHex(number byte, out []byte) {
+	out[0] = ascii(number / 16)
+	out[1] = ascii(number % 16)
+}
+
+func ascii(digit byte) byte {
+	const asciiA, ascii0 = 65, 48
+	if digit > 9 {
+		return asciiA + digit - 10
+	}
+	return ascii0 + digit
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -14,8 +14,10 @@ import (
 func TestRGB_String(t *testing.T) {
 	tests := map[string]vm.RGB{
 		"#000000": {},
-		"#010203": {1, 2, 3},
-		"#102030": {0x10, 0x20, 0x30},
+		"#FFFFFF": {0xFF, 0xFF, 0xFF},
+		"#012345": {0x01, 0x23, 0x45},
+		"#6789AB": {0x67, 0x89, 0xAB},
+		"#CDEF01": {0xCD, 0xEF, 0x01},
 	}
 
 	for expected, rgb := range tests {


### PR DESCRIPTION
vm package is using fmt.Sprintf to print RGB as hex. This dependency is a lot of code and should not be a part of package imported practically by every package.