### PR TITLE
Set screen size limit

### DIFF
--- a/pi_test.go
+++ b/pi_test.go
@@ -5,6 +5,7 @@ package pi_test
 
 import (
 	_ "embed"
+	"fmt"
 	"strconv"
 	"testing"
 	"testing/fstest"
@@ -124,6 +125,39 @@ func TestSetScreenSize(t *testing.T) {
 				pi.Reset()
 				assert.Panics(t, func() {
 					pi.SetScreenSize(pi.Scr().Width(), size)
+				})
+			})
+		}
+	})
+
+	t.Run("should panic when total number of pixels is higher than 65536", func(t *testing.T) {
+		tests := []struct{ w, h int }{
+			{w: 65537, h: 1},
+			{w: 1, h: 65537},
+		}
+
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%dx%d", test.w, test.h), func(t *testing.T) {
+				pi.Reset()
+				assert.Panics(t, func() {
+					pi.SetScreenSize(test.w, test.h)
+				})
+			})
+		}
+	})
+
+	t.Run("should not panic when total number of pixels is lower/equal than 65536", func(t *testing.T) {
+		tests := []struct{ w, h int }{
+			{w: 1024, h: 64},
+			{w: 256, h: 256},
+			{w: 320, h: 200},
+		}
+
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%dx%d", test.w, test.h), func(t *testing.T) {
+				pi.Reset()
+				assert.NotPanics(t, func() {
+					pi.SetScreenSize(test.w, test.h)
 				})
 			})
 		}

--- a/screen.go
+++ b/screen.go
@@ -231,13 +231,21 @@ type Position struct {
 	X, Y int
 }
 
-func SetScreenSize(w, h int) {
-	if w <= 0 {
-		panic(fmt.Sprintf("screen width %d is not greather than 0", w))
+const maxScreenSize = 1024 * 64
+
+// SetScreenSize sets the screen size to specified resolution. The maximum number of pixels is 65536 (64KB).
+// Will panic if screen size is too big or width/height are <= 0.
+func SetScreenSize(width, height int) {
+	if width <= 0 {
+		panic(fmt.Sprintf("screen width %d is not greather than 0", width))
 	}
-	if h <= 0 {
-		panic(fmt.Sprintf("screen height %d is not greather than 0", h))
+	if height <= 0 {
+		panic(fmt.Sprintf("screen height %d is not greather than 0", height))
 	}
 
-	screen = NewPixMap(w, h)
+	if width*height > maxScreenSize {
+		panic(fmt.Sprintf("number of pixels for screen resolution %dx%d is higher than maximum %d. Please use smaller screen.", width, height, maxScreenSize))
+	}
+
+	screen = NewPixMap(width, height)
 }


### PR DESCRIPTION
Limit the maximum screen size to 65536 (64KB) for following reasons:

* bigger screens are not good for pixel-perfect programming
* the more pixels, the longer it takes to create game assets
* PI uses CPU for screen manipulation, which means it is slow for high resolutions such as FullHD or 4K