### PR TITLE
Make game window floating all time

### DIFF
--- a/ebitengine/ebitengine.go
+++ b/ebitengine/ebitengine.go
@@ -39,6 +39,7 @@ func Run() error {
 	ebiten.SetWindowSize(screen.Width()*scale(), screen.Height()*scale())
 	ebiten.SetWindowSizeLimits(screen.Width(), screen.Height(), -1, -1)
 	ebiten.SetCursorMode(ebiten.CursorModeHidden)
+	ebiten.SetWindowFloating(true)
 	ebiten.SetWindowTitle("Pi Game")
 
 	if err := ebiten.RunGame(&game{}); err != nil {


### PR DESCRIPTION
Window should be always on top. It is very handy for game developer. In the future we might want to add a Pi parameter to configure that.