### PR TITLE
Implement audio.LiveReader

### DIFF
--- a/audio/internal.go
+++ b/audio/internal.go
@@ -1,3 +1,6 @@
+// (c) 2022-2023 Jacek Olszak
+// This code is licensed under MIT license (see LICENSE for details)
+
 package audio
 
 import (

--- a/audio/internal_test.go
+++ b/audio/internal_test.go
@@ -1,3 +1,6 @@
+// (c) 2022-2023 Jacek Olszak
+// This code is licensed under MIT license (see LICENSE for details)
+
 package audio
 
 import (

--- a/audio/live.go
+++ b/audio/live.go
@@ -1,0 +1,65 @@
+// (c) 2022-2023 Jacek Olszak
+// This code is licensed under MIT license (see LICENSE for details)
+
+package audio
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/elgopher/pi"
+	"github.com/elgopher/pi/audio/internal"
+)
+
+const frameDuration = time.Second / internal.SampleRate
+
+// LiveReader is used by backend to read samples live taking into consideration current time.
+// It drops frames when ReadSamples was called too late, and limits how much frames can be read.
+type LiveReader struct {
+	BufferSize      time.Duration
+	ReadSamplesFunc func([]float64)
+	Now             func() time.Time
+
+	started      time.Time
+	lastFrame    int
+	reusedBuffer []float64
+}
+
+// ReadSamples reads samples and writes them to buf. Returns how much samples was written to buffer.
+func (l *LiveReader) ReadSamples(buf []float64) int {
+	now := l.Now()
+	if l.started.IsZero() {
+		l.started = now
+		return 0
+	}
+
+	maxRealFrame := int(now.Sub(l.started) / frameDuration)
+	maxCallerFrame := l.lastFrame + len(buf)
+	maxFrame := pi.MinInt(maxRealFrame, maxCallerFrame)
+
+	framesToDrop := maxRealFrame - maxCallerFrame - int(l.BufferSize/frameDuration) + 1
+	if framesToDrop > 0 {
+		l.dropFrames(framesToDrop)
+	}
+
+	n := maxFrame - l.lastFrame
+	l.ReadSamplesFunc(buf[:n])
+
+	l.lastFrame = maxFrame
+
+	return n
+}
+
+func (l *LiveReader) dropFrames(framesToDrop int) {
+	fmt.Printf("dropping %d audio frames\n", framesToDrop)
+
+	if l.reusedBuffer == nil {
+		l.reusedBuffer = make([]float64, 1024)
+	}
+
+	for framesToDrop > 0 {
+		n := pi.MinInt(framesToDrop, len(l.reusedBuffer))
+		l.ReadSamplesFunc(l.reusedBuffer[:n])
+		framesToDrop -= n
+	}
+}

--- a/audio/live_test.go
+++ b/audio/live_test.go
@@ -1,0 +1,170 @@
+// (c) 2022-2023 Jacek Olszak
+// This code is licensed under MIT license (see LICENSE for details)
+
+package audio_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elgopher/pi/audio"
+)
+
+const frameDuration = time.Second / audio.SampleRate
+
+func TestLiveReader_ReadSamples(t *testing.T) {
+	t.Run("should not read anything on first call", func(t *testing.T) {
+		c := newClock()
+		r := audio.LiveReader{
+			BufferSize:      time.Second,
+			ReadSamplesFunc: readSamplesSeq(),
+			Now:             c.Now,
+		}
+		buf := make([]float64, 1)
+		// when
+		n := r.ReadSamples(buf)
+		// then
+		assert.Zero(t, n)
+		assertSilence(t, buf)
+	})
+
+	t.Run("should read one sample", func(t *testing.T) {
+		c := newClock()
+		r := prepareLiveReader(c)
+		c.advance(frameDuration)
+		buf := make([]float64, 1)
+		// when
+		n := r.ReadSamples(buf)
+		// then
+		assert.Equal(t, 1, n)
+		assert.Equal(t, []float64{1}, buf)
+	})
+
+	t.Run("should read two samples", func(t *testing.T) {
+		c := newClock()
+		r := prepareLiveReader(c)
+		c.advance(2 * frameDuration)
+		buf := make([]float64, 2)
+		// when
+		n := r.ReadSamples(buf)
+		// then
+		assert.Equal(t, 2, n)
+		assert.Equal(t, []float64{1, 2}, buf)
+	})
+
+	t.Run("should read only one sample even though buffer is bigger because its to early", func(t *testing.T) {
+		c := newClock()
+		r := prepareLiveReader(c)
+		c.advance(frameDuration) // only one frame elapsed, so only one sample will be read
+		buf := make([]float64, 2)
+		// when
+		n := r.ReadSamples(buf)
+		// then
+		assert.Equal(t, 1, n)
+		assert.Equal(t, []float64{1, 0}, buf)
+	})
+
+	t.Run("should read samples up to the buffer size", func(t *testing.T) {
+		c := newClock()
+		r := prepareLiveReader(c)
+		c.advance(2 * frameDuration) // two frames elapsed, but buffer is not big enough to read all
+		buf := make([]float64, 1)
+		// when
+		n := r.ReadSamples(buf)
+		// then
+		assert.Equal(t, 1, n)
+		assert.Equal(t, []float64{1}, buf)
+	})
+
+	t.Run("should read all samples in two calls", func(t *testing.T) {
+		c := newClock()
+		r := prepareLiveReader(c)
+		c.advance(2 * frameDuration) // two frames elapsed, but buffer is not big enough to read all
+		buf := make([]float64, 1)
+		r.ReadSamples(buf)
+		// when
+		n := r.ReadSamples(buf)
+		// then
+		assert.Equal(t, 1, n)
+		assert.Equal(t, []float64{2}, buf)
+	})
+
+	t.Run("should not read anything when its to early and previously samples were read", func(t *testing.T) {
+		c := newClock()
+		r := prepareLiveReader(c)
+		c.advance(frameDuration)
+		r.ReadSamples(make([]float64, 1))
+		buf := make([]float64, 1)
+		// when
+		n := r.ReadSamples(buf)
+		// then
+		assert.Zero(t, n)
+		assertSilence(t, buf)
+	})
+
+	t.Run("should drop frame when its too late", func(t *testing.T) {
+		c := newClock()
+		r := prepareLiveReaderWithBufferSize(c, frameDuration)
+		c.advance(2 * frameDuration) // advance two frames, but because buffer size is one frame then first frame will be dropped
+		buf := make([]float64, 1)
+		// when
+		n := r.ReadSamples(buf)
+		// then
+		assert.Equal(t, 1, n)
+		assert.Equal(t, []float64{2}, buf)
+	})
+
+	t.Run("should drop huge number of frames", func(t *testing.T) {
+		c := newClock()
+		r := prepareLiveReaderWithBufferSize(c, frameDuration)
+		c.advance(65537 * frameDuration) // 65536 frames to drop
+		buf := make([]float64, 1)
+		// when
+		n := r.ReadSamples(buf)
+		// then
+		assert.Equal(t, 1, n)
+		assert.Equal(t, []float64{65537}, buf)
+	})
+}
+
+type clock struct {
+	now time.Time
+}
+
+func newClock() *clock {
+	return &clock{now: time.UnixMilli(1)}
+}
+
+func (c *clock) Now() time.Time {
+	return c.now
+}
+
+func (c *clock) advance(duration time.Duration) {
+	c.now = c.now.Add(duration)
+}
+
+func readSamplesSeq() func(buf []float64) {
+	n := 1.0
+	return func(buf []float64) {
+		for i := 0; i < len(buf); i++ {
+			buf[i] = n
+			n++
+		}
+	}
+}
+
+func prepareLiveReader(c *clock) *audio.LiveReader {
+	return prepareLiveReaderWithBufferSize(c, time.Second)
+}
+
+func prepareLiveReaderWithBufferSize(c *clock, bufferSize time.Duration) *audio.LiveReader {
+	r := &audio.LiveReader{
+		BufferSize:      bufferSize,
+		ReadSamplesFunc: readSamplesSeq(),
+		Now:             c.Now,
+	}
+	r.ReadSamples(make([]float64, 0)) // first read does not read samples
+	return r
+}

--- a/audio/synth.go
+++ b/audio/synth.go
@@ -11,6 +11,8 @@ import (
 	"github.com/elgopher/pi/audio/internal"
 )
 
+const SampleRate = internal.SampleRate
+
 // Synthesizer is used by a back-end. It is an System implementation.
 // Plus it provides method for synthesizing audio samples.
 type Synthesizer struct {

--- a/ebitengine/audio.go
+++ b/ebitengine/audio.go
@@ -61,18 +61,22 @@ func startAudio() (stop func(), ready <-chan struct{}, _ error) {
 	}
 
 	audioCtx := ebitenaudio.NewContext(audioSampleRate)
+
 	player, err := audioCtx.NewPlayer(AudioStream)
 	if err != nil {
 		return func() {}, nil, err
 	}
 	player.SetBufferSize(60 * time.Millisecond)
-	player.Play()
 
 	readyChan := make(chan struct{})
+
 	go func() {
 		for {
 			if audioCtx.IsReady() {
 				close(readyChan)
+
+				player.Play()
+
 				return
 			}
 			time.Sleep(time.Millisecond)

--- a/ebitengine/audio.go
+++ b/ebitengine/audio.go
@@ -158,13 +158,6 @@ func (e *ebitenPlayerSource) ensureFloatBufferIsBigEnough(size int) {
 	}
 }
 
-func (e *ebitenPlayerSource) ReadSamples(b []float64) {
-	e.mutex.Lock()
-	defer e.mutex.Unlock()
-
-	e.audioSystem.ReadSamples(b)
-}
-
 func (e *ebitenPlayerSource) Sfx(sfxNo int, channel audio.Channel, offset, length int) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()

--- a/ebitengine/audio_test.go
+++ b/ebitengine/audio_test.go
@@ -22,72 +22,98 @@ func TestEbitenPlayerSource_Read(t *testing.T) {
 	})
 
 	t.Run("should convert floats to linear PCM (signed 16bits little endian, 2 channel stereo).", func(t *testing.T) {
+		audioSystem := &audioSystemMock{buffer: []float64{-1, 0, 1, -0.5, 0.5}}
 		reader := &ebitenPlayerSource{
-			audioSystem: &audioSystemMock{buffer: []float64{-1, 0, 1, -0.5, 0.5}},
+			audioSystem: audioSystem,
+			readSamples: audioSystem.ReadSamples,
 		}
-		actual := make([]byte, 20)
+		actual := make([]byte, 40)
 		// when
 		n, err := reader.Read(actual)
 		// then
 		require.NoError(t, err)
-		assert.Equal(t, 20, n)
+		assert.Equal(t, 40, n)
 		assert.Equal(t, []byte{
 			1, 0x80, // -1, left channel, second byte, 7 bit has sign bit
 			1, 0x80, // right channel - copy of left channel
+			1, 0x80, // copy of left channel (because Ebitengine is using 44100 but Pi 22050)
+			1, 0x80, // copy of right channel
+			0, 0, // 0
+			0, 0, // 0
 			0, 0, // 0
 			0, 0, // 0
 			0xFF, 0x7F, // 1
 			0xFF, 0x7F, // 1
+			0xFF, 0x7F, // 1
+			0xFF, 0x7F, // 1
 			1, 0xC0, // -0.5
 			1, 0xC0, // -0.5
+			1, 0xC0, // -0.5
+			1, 0xC0, // -0.5
+			0xFF, 0x3F, // 0.5
+			0xFF, 0x3F, // 0.5
 			0xFF, 0x3F, // 0.5
 			0xFF, 0x3F, // 0.5
 		}, actual)
 	})
 
 	t.Run("should continue reading stream using bigger buffer than before", func(t *testing.T) {
+		audioSystem := &audioSystemMock{buffer: []float64{1, -0.5, 0.5}}
 		reader := &ebitenPlayerSource{
-			audioSystem: &audioSystemMock{buffer: []float64{1, -0.5, 0.5}},
+			audioSystem: audioSystem,
+			readSamples: audioSystem.ReadSamples,
 		}
-		smallBuffer := make([]byte, 4)
+		smallBuffer := make([]byte, 8)
 		n, err := reader.Read(smallBuffer)
-		require.Equal(t, 4, n)
+		require.Equal(t, 8, n)
 		require.NoError(t, err)
-		biggerBuffer := make([]byte, 8)
+		biggerBuffer := make([]byte, 16)
 		// when
 		n, err = reader.Read(biggerBuffer)
 		// then
-		assert.Equal(t, 8, n)
+		assert.Equal(t, 16, n)
 		require.NoError(t, err)
 		assert.Equal(t, []byte{
 			1, 0xC0, // -0.5
 			1, 0xC0, // -0.5
+			1, 0xC0, // -0.5
+			1, 0xC0, // -0.5
+			0xFF, 0x3F, // 0.5
+			0xFF, 0x3F, // 0.5
 			0xFF, 0x3F, // 0.5
 			0xFF, 0x3F, // 0.5
 		}, biggerBuffer)
 	})
 
 	t.Run("should clamp float values to [-1,1]", func(t *testing.T) {
+		audioSystem := &audioSystemMock{buffer: []float64{-2, 2}}
 		reader := &ebitenPlayerSource{
-			audioSystem: &audioSystemMock{buffer: []float64{-2, 2}},
+			audioSystem: audioSystem,
+			readSamples: audioSystem.ReadSamples,
 		}
-		actual := make([]byte, 8)
+		actual := make([]byte, 16)
 		// when
 		n, err := reader.Read(actual)
 		// then
 		require.NoError(t, err)
-		assert.Equal(t, 8, n)
+		assert.Equal(t, 16, n)
 		assert.Equal(t, []byte{
 			1, 0x80, // -2 clamped to -1
 			1, 0x80,
+			1, 0x80,
+			1, 0x80,
 			0xFF, 0x7F, // 2 clamped to 1
+			0xFF, 0x7F,
+			0xFF, 0x7F,
 			0xFF, 0x7F,
 		}, actual)
 	})
 
 	t.Run("should convert floats even when buffer is too small", func(t *testing.T) {
+		audioSystem := &audioSystemMock{buffer: []float64{1, -1}}
 		reader := &ebitenPlayerSource{
-			audioSystem: &audioSystemMock{buffer: []float64{1, -1}},
+			audioSystem: audioSystem,
+			readSamples: audioSystem.ReadSamples,
 		}
 		actual := make([]byte, 8)
 
@@ -106,17 +132,18 @@ func TestEbitenPlayerSource_Read(t *testing.T) {
 	})
 
 	t.Run("should only read the minimum number of floats", func(t *testing.T) {
-		mock := &audioSystemMock{buffer: []float64{0, 1, -1, 0}}
+		audioSystem := &audioSystemMock{buffer: []float64{0, 1, -1, 0}}
 		reader := &ebitenPlayerSource{
-			audioSystem: mock,
+			audioSystem: audioSystem,
+			readSamples: audioSystem.ReadSamples,
 		}
-		n, err := reader.Read(make([]byte, 8)) // read 2 samples first
+		n, err := reader.Read(make([]byte, 16)) // read 2 samples first
+		require.NoError(t, err)
+		require.Equal(t, 16, n)
+		n, err = reader.Read(make([]byte, 8)) // read 1 sample only
 		require.NoError(t, err)
 		require.Equal(t, 8, n)
-		n, err = reader.Read(make([]byte, 4)) // read 1 sample only
-		require.NoError(t, err)
-		require.Equal(t, 4, n)
-		assert.Len(t, mock.buffer, 1, "one float in the buffer should still be available for reading")
+		assert.Len(t, audioSystem.buffer, 1, "one float in the buffer should still be available for reading")
 	})
 }
 
@@ -124,6 +151,9 @@ func TestEbitenPlayerSource_ThreadSafety(t *testing.T) {
 	t.Run("should not fail when run with -race flag", func(t *testing.T) {
 		reader := &ebitenPlayerSource{
 			audioSystem: &audio.Synthesizer{},
+			readSamples: func(buf []float64) int {
+				return len(buf)
+			},
 		}
 
 		const goroutines = 100
@@ -158,9 +188,10 @@ type audioSystemMock struct {
 	buffer []float64
 }
 
-func (m *audioSystemMock) ReadSamples(buffer []float64) {
+func (m *audioSystemMock) ReadSamples(buffer []float64) int {
 	n := copy(buffer, m.buffer)
 	m.buffer = m.buffer[n:]
+	return n
 }
 
 func (m *audioSystemMock) Sfx(sfxNo int, channel audio.Channel, offset, length int) {}


### PR DESCRIPTION
LiveReader is used by backend to read samples live taking into consideration current time.

LiveReader drops frames when ReadSamples was called too late, and  limits how much frames can be read.