### PR TITLE
Remove x,y,w,h from PixMap.Copy, Merge and Foreach

### DIFF
--- a/devtools/internal/inspector/spr.go
+++ b/devtools/internal/inspector/spr.go
@@ -65,7 +65,7 @@ func (m *sprSelectionMode) update(spr *Spr) {
 }
 
 func (m *sprSelectionMode) draw() {
-	pi.SprSheet().Copy(0, 0, pi.SprSheet().Width(), pi.SprSheet().Height(), pi.Scr(), m.camera.X, m.camera.Y)
+	pi.SprSheet().Copy(pi.Scr(), m.camera.X, m.camera.Y)
 
 	mouseX, mouseY := pi.MousePos.X, pi.MousePos.Y
 

--- a/examples/pixmap/main.go
+++ b/examples/pixmap/main.go
@@ -16,20 +16,23 @@ func main() {
 	pi.Load(resources)
 
 	// copy from sprite-sheet to sprite-sheet:
-	pi.SprSheet().Copy(10, 0, 100, 100, pi.SprSheet(), 0, 0)
+	src := pi.SprSheet().WithClip(10, 0, 100, 100)
+	src.Copy(pi.SprSheet(), 0, 0)
 
 	// draw a filled rectangle directly to sprite-sheet:
 	pi.SprSheet().RectFill(60, 30, 70, 40, 7)
 
 	// merge from sprite-sheet to screen using custom merge function, which merges two lines
-	pi.SprSheet().Merge(-1, -1, 103, 70, pi.Scr(), -1, -1, func(dst, src []byte) {
+	src = pi.SprSheet().WithClip(-1, -1, 103, 70)
+	src.Merge(pi.Scr(), -1, -1, func(dst, src []byte) {
 		for x := 0; x < len(dst); x++ {
 			dst[x] += pi.Pal[src[x]] + 1
 		}
 	})
 
 	// update each line in a loop:
-	pi.Scr().Foreach(10, 10, 16, 16, func(x, y int, line []byte) {
+	src = pi.Scr().WithClip(10, 10, 16, 16)
+	src.Foreach(func(x, y int, line []byte) {
 		for i := 0; i < len(line); i++ {
 			line[i] = byte(i)
 		}

--- a/internal/bench/pixmap_bench_test.go
+++ b/internal/bench/pixmap_bench_test.go
@@ -28,7 +28,7 @@ func BenchmarkPixMapPointer(b *testing.B) {
 func BenchmarkCopy(b *testing.B) {
 	runBenchmarks(b, func(res Resolution) {
 		for i := 0; i < 100; i++ {
-			pi.SprSheet().Copy(0, 0, 16, 16, pi.Scr(), 16, 16) // 2x times faster than SprSize
+			pi.SprSheet().WithClip(0, 0, 16, 16).Copy(pi.Scr(), 16, 16) // 2x times faster than SprSize
 		}
 	})
 }
@@ -38,7 +38,7 @@ func SrcAtop(dst, src []byte) { copy(dst, src) }
 func BenchmarkMerge(b *testing.B) {
 	runBenchmarks(b, func(res Resolution) {
 		for i := 0; i < 100; i++ {
-			pi.SprSheet().Merge(0, 0, 16, 16, pi.Scr(), 16, 16, SrcAtop) // FAST! NOT AS FAST AS COPY BUT THE PERF IS GREAT!
+			pi.SprSheet().WithClip(0, 0, 16, 16).Merge(pi.Scr(), 16, 16, SrcAtop) // FAST! NOT AS FAST AS COPY BUT THE PERF IS GREAT!
 		}
 	})
 }
@@ -47,7 +47,7 @@ func BenchmarkForeach(b *testing.B) {
 	src := make([]byte, 16)
 	runBenchmarks(b, func(res Resolution) {
 		for i := 0; i < 100; i++ {
-			pi.Scr().Foreach(0, 0, 16, 16, func(x, y int, dst []byte) { copy(dst, src) })
+			pi.Scr().WithClip(0, 0, 16, 16).Foreach(func(x, y int, dst []byte) { copy(dst, src) })
 		}
 	})
 }

--- a/internal/fuzz/pixmap_test.go
+++ b/internal/fuzz/pixmap_test.go
@@ -22,7 +22,8 @@ func FuzzPixMap_Pointer(f *testing.F) {
 func FuzzPixMap_Foreach(f *testing.F) {
 	pixMap := pi.NewPixMap(2, 3)
 	f.Fuzz(func(t *testing.T, x, y, w, h, dstX, dstY int) {
-		pixMap.Foreach(x, y, w, h, func(x, y int, dst []byte) {
+		src := pixMap.WithClip(x, y, w, h)
+		src.Foreach(func(x, y int, dst []byte) {
 			dst[0] = byte(x + y)
 		})
 	})
@@ -33,7 +34,7 @@ func FuzzPixMap_Copy_Src_Bigger(f *testing.F) {
 	dst := pi.NewPixMap(2, 3)
 
 	f.Fuzz(func(t *testing.T, x, y, w, h, dstX, dstY int) {
-		src.Copy(x, y, w, h, dst, dstX, dstY)
+		src.WithClip(x, y, w, h).Copy(dst, dstX, dstY)
 	})
 }
 
@@ -42,7 +43,7 @@ func FuzzPixMap_Copy_Dst_Bigger(f *testing.F) {
 	dst := pi.NewPixMap(5, 4)
 
 	f.Fuzz(func(t *testing.T, x, y, w, h, dstX, dstY int) {
-		src.Copy(x, y, w, h, dst, dstX, dstY)
+		src.WithClip(x, y, w, h).Copy(dst, dstX, dstY)
 	})
 }
 
@@ -51,7 +52,7 @@ func FuzzPixMap_Merge(f *testing.F) {
 	dst := pi.NewPixMap(4, 3)
 
 	f.Fuzz(func(t *testing.T, x, y, w, h, dstX, dstY int) {
-		src.Merge(x, y, w, h, dst, dstX, dstY, func(dst, src []byte) {
+		src.WithClip(x, y, w, h).Merge(dst, dstX, dstY, func(dst, src []byte) {
 			copy(dst, src)
 		})
 	})


### PR DESCRIPTION
[ ] For now it is not compatible with original code, mainly because clipping region information is lost during WithClip