### PR TITLE
Fix go run syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Perfect for small projects, prototypes, jams — or simply to have fun.
 2. Try examples from the [_examples](_examples) directory
     * Run the Snake example directly:
       ```bash
-      go run github.com/elgopher/pi/_examples/snake
+      go run github.com/elgopher/pi/_examples/snake@latest
       ```
     * Or clone the Pi repository and modify the example:
       ```bash


### PR DESCRIPTION
Go reports error  for user command

`> go run github.com/elgopher/pi/_examples/snake
no required module provides package github.com/elgopher/pi/_examples/snake: go.mod file not found in current directory or any parent directory; see 'go help modules' `

The message is misleading. Starting from Go 1.17, go run requires @version suffix.