### PR TITLE
Rename pigui.Element callbacks

### DIFF
--- a/_examples/gui/main.go
+++ b/_examples/gui/main.go
@@ -40,7 +40,7 @@ func main() {
 	// add a button with a callback that runs when the user clicks
 	// and releases the left mouse button while staying inside its area
 	btn3 := attachButton(panel, 10, 41, 44, 14, "BUTTON 3")
-	btn3.OnTapped = func(event pigui.Event) {
+	btn3.OnTap = func(event pigui.Event) {
 		log.Println("Button 3 was tapped")
 	}
 

--- a/pigui/pigui.go
+++ b/pigui/pigui.go
@@ -38,13 +38,13 @@ func Attach(parent *Element, x, y, w, h int) *Element {
 type Element struct {
 	pi.Area[int]
 
-	OnDraw     func(DrawEvent)
-	OnUpdate   func(UpdateEvent)
-	OnPressed  func(Event)
-	OnReleased func(Event)
-	OnTapped   func(Event)
-	children   []*Element
-	pressed    bool
+	OnDraw    func(DrawEvent)
+	OnUpdate  func(UpdateEvent)
+	OnPress   func(Event)
+	OnRelease func(Event)
+	OnTap     func(Event)
+	children  []*Element
+	pressed   bool
 }
 
 // Attach re-attaches an existing element to the parent e.
@@ -91,23 +91,23 @@ func (e *Element) Update() {
 
 	if hasPointer && mouseLeft == 1 {
 		e.pressed = true
-		if e.OnPressed != nil {
-			e.OnPressed(Event{
+		if e.OnPress != nil {
+			e.OnPress(Event{
 				Element:    e,
 				HasPointer: true,
 			})
 		}
 	} else if e.pressed && mouseLeft == 0 {
 		e.pressed = false
-		if e.OnReleased != nil {
-			e.OnReleased(Event{
+		if e.OnRelease != nil {
+			e.OnRelease(Event{
 				Element:    e,
 				HasPointer: hasPointer,
 			})
 		}
 		if hasPointer {
-			if e.OnTapped != nil {
-				e.OnTapped(Event{
+			if e.OnTap != nil {
+				e.OnTap(Event{
 					Element:    e,
 					HasPointer: true,
 				})

--- a/piscope/internal/gui.go
+++ b/piscope/internal/gui.go
@@ -24,12 +24,12 @@ func attachToolbar(parent *pigui.Element) *pigui.Element {
 	// attachIconButton(toolbar, icons.Paint, 32) // icon hidden until implemented
 
 	snap := attachIconButton(toolbar, icons.Snap, pi.Screen().W()-34)
-	snap.OnTapped = func(event pigui.Event) {
+	snap.OnTap = func(event pigui.Event) {
 		captureSnapshot()
 	}
 
 	prev := attachIconButton(toolbar, icons.Prev, pi.Screen().W()-24)
-	prev.OnTapped = func(event pigui.Event) {
+	prev.OnTap = func(event pigui.Event) {
 		showPrevSnapshot()
 	}
 	prev.OnUpdate = func(pigui.UpdateEvent) {
@@ -41,7 +41,7 @@ func attachToolbar(parent *pigui.Element) *pigui.Element {
 	}
 
 	playPause := attachIconButton(toolbar, icons.Pause, pi.Screen().W()-19)
-	playPause.OnTapped = func(pigui.Event) {
+	playPause.OnTap = func(pigui.Event) {
 		pauseOrResume()
 	}
 	playPause.OnUpdate = func(pigui.UpdateEvent) {
@@ -53,12 +53,12 @@ func attachToolbar(parent *pigui.Element) *pigui.Element {
 	}
 
 	next := attachIconButton(toolbar, icons.Next, pi.Screen().W()-14)
-	next.OnTapped = func(event pigui.Event) {
+	next.OnTap = func(event pigui.Event) {
 		showNextSnapshot()
 	}
 
 	exit := attachIconButton(toolbar, icons.Exit, pi.Screen().W()-8)
-	exit.OnTapped = func(event pigui.Event) {
+	exit.OnTap = func(event pigui.Event) {
 		exitConsoleMode()
 	}
 


### PR DESCRIPTION
Because callback names are not consistent. For example, Element.OnTapped vs. Element.OnDraw.