### PR TITLE
Improve performance: Use cached palette mapping

### DIFF
--- a/palettemap.go
+++ b/palettemap.go
@@ -14,7 +14,7 @@ import (
 // the contents of the Screen to the game window.
 //
 // The array index is the original color, and the value is the mapped color.
-var PaletteMapping PaletteMap = notSwappedPaletteMapping()
+var PaletteMapping PaletteMap = notSwappedPaletteMapping
 
 // PaletteMap defines the color mapping for display.
 //
@@ -32,13 +32,13 @@ func (p PaletteMap) String() string {
 }
 
 func ResetPaletteMapping() {
-	PaletteMapping = notSwappedPaletteMapping()
+	PaletteMapping = notSwappedPaletteMapping
 }
 
-func notSwappedPaletteMapping() PaletteMap {
+var notSwappedPaletteMapping = func() PaletteMap {
 	var m PaletteMap
 	for i := 0; i < MaxColors; i++ {
 		m[i] = Color(i)
 	}
 	return m
-}
+}()


### PR DESCRIPTION
Instead of generating it on the fly.