### PR TITLE
fix: adjust audio buffer size to different OSes

### DIFF
--- a/piebiten/internal/audio_darwin.go
+++ b/piebiten/internal/audio_darwin.go
@@ -1,0 +1,6 @@
+// Copyright 2025 Jacek Olszak
+// This code is licensed under MIT license (see LICENSE for details)
+
+package internal
+
+const audioBufferSizeInSeconds = 0.04 // 40ms

--- a/piebiten/internal/audio_unix.go
+++ b/piebiten/internal/audio_unix.go
@@ -1,7 +1,7 @@
 // Copyright 2025 Jacek Olszak
 // This code is licensed under MIT license (see LICENSE for details)
 
-//go:build !js
+//go:build freebsd || linux || netbsd || openbsd
 
 package internal
 

--- a/piebiten/internal/audio_windows.go
+++ b/piebiten/internal/audio_windows.go
@@ -1,0 +1,6 @@
+// Copyright 2025 Jacek Olszak
+// This code is licensed under MIT license (see LICENSE for details)
+
+package internal
+
+const audioBufferSizeInSeconds = 0.02 // 20ms


### PR DESCRIPTION
On macOS, the audio is choppy for 20 ms audio buffer. Use 40 ms instead.