### PR TITLE
fix: time increment too slow

### DIFF
--- a/piebiten/internal/ebitengame.go
+++ b/piebiten/internal/ebitengame.go
@@ -145,7 +145,7 @@ func (g *EbitenGame) Update() error {
 			g.skipNextDraw = true // game is too slow. Try to keep up by discarding next pi.Draw()
 		}
 
-		pi.Time += 1 / ebitenTPS
+		pi.Time += 1.0 / float64(pi.TPS())
 		pi.Frame++
 	}
 


### PR DESCRIPTION
In each call to pi.Update, time was being increased by 1/60 of a second. However, it should be increased by a value based on pi.TPS, not a fixed 60 ticks. For pi.TPS 30, time should increase by 1/30 of a second; for pi.TPS 15, by 1/15 of a second.