### PR TITLE
refactor: use pitch ratio instead of frequency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/_examples/audio/main.go
+++ b/_examples/audio/main.go
@@ -21,7 +21,7 @@ import (
 var clickWav []byte
 
 func main() {
-	sample := piaudio.DecodeWav(clickWav, 2349.32)
+	sample := piaudio.DecodeWav(clickWav)
 
 	piloop.Target().Subscribe(piloop.EventGameStarted, func(piloop.Event, pievent.Handler) {
 		// The sample must be loaded before use,
@@ -51,8 +51,8 @@ func main() {
 			// gradually reduce the volume to 0
 			piaudio.SetVolume(piaudio.Chan1, i, delay)
 
-			// gradually reduce the pitch down to ~340
-			pitch := 540 - delay*200
+			// gradually reduce the pitch down to 0
+			pitch := 1.0 - delay
 			piaudio.SetPitch(piaudio.Chan1, pitch, delay)
 			delay += 0.01
 		}

--- a/piaudio/backend.go
+++ b/piaudio/backend.go
@@ -22,7 +22,10 @@ type BackendInterface interface {
 	SetLoop(_ Chan, start int, stop int, loop LoopType, delay float64)
 
 	// SetPitch schedules the pitch change to take effect after the specified delay.
-	SetPitch(_ Chan, pitch Freq, delay float64)
+	// A pitch of 1.0 plays the sample at its original speed.
+	// Values below 1.0 slow down the sample and lower its pitch (e.g., 0.5 = one octave lower),
+	// while values above 1.0 speed it up and raise the pitch.
+	SetPitch(_ Chan, pitch float64, delay float64)
 
 	// SetVolume schedules the volume change to take effect after the specified delay.
 	SetVolume(_ Chan, vol float64, delay float64)
@@ -53,7 +56,7 @@ func (p panicBackend) ClearChan(ch Chan, delay float64) {
 	panic("cannot clear channel: backend not set. Please call ClearChan only after starting the game")
 }
 
-func (p panicBackend) SetPitch(_ Chan, pitch Freq, delay float64) {
+func (p panicBackend) SetPitch(_ Chan, pitch float64, delay float64) {
 	panic("cannot set pitch: backend not set. Please call SetPitch only after starting the game")
 }
 

--- a/piaudio/piaudio.go
+++ b/piaudio/piaudio.go
@@ -42,18 +42,6 @@
 // Once created, a *Sample can be loaded into the backend using LoadSample.
 package piaudio
 
-// Freq represents frequency in Hz.
-type Freq = float64
-
-// Predefined common musical pitches in Hz.
-const (
-	A4 Freq = 440.0  // Standard tuning reference
-	C4 Freq = 261.63 // Middle C
-	E4 Freq = 329.63
-	G4 Freq = 392.00
-	A5 Freq = 880.0
-)
-
 // Chan represents an audio channel number.
 type Chan = uint8
 
@@ -84,7 +72,10 @@ func SetLoop(ch Chan, start int, stop int, loop LoopType, delay float64) {
 }
 
 // SetPitch schedules the pitch change to take effect after the specified delay.
-func SetPitch(ch Chan, pitch Freq, delay float64) {
+// A pitch of 1.0 plays the sample at its original speed.
+// Values below 1.0 slow down the sample and lower its pitch (e.g., 0.5 = one octave lower),
+// while values above 1.0 speed it up and raise the pitch.
+func SetPitch(ch Chan, pitch float64, delay float64) {
 	Backend.SetPitch(ch, pitch, delay)
 }
 

--- a/piaudio/sample.go
+++ b/piaudio/sample.go
@@ -4,15 +4,15 @@
 package piaudio
 
 // NewSample creates a new *Sample from raw 8-bit mono PCM data.
-// baseFreq specifies the base frequency of the sample in Hz.
-func NewSample(data []int8, baseFreq Freq) *Sample {
-	return &Sample{data: data, baseFreq: baseFreq}
+// sampleRate determines how many times per second a sample value is read (in Hz).
+func NewSample(data []int8, sampleRate uint16) *Sample {
+	return &Sample{data: data, sampleRate: sampleRate}
 }
 
-// Sample represents raw 8-bit mono PCM audio data along with its base frequency.
+// Sample represents raw 8-bit mono PCM audio data along with its sample rate.
 type Sample struct {
-	data     []int8
-	baseFreq Freq
+	data       []int8
+	sampleRate uint16
 }
 
 func (s *Sample) Data() []int8 {
@@ -23,6 +23,6 @@ func (s *Sample) Len() int {
 	return len(s.data)
 }
 
-func (s *Sample) BaseFreq() float64 {
-	return s.baseFreq
+func (s *Sample) SampleRate() uint16 {
+	return s.sampleRate
 }


### PR DESCRIPTION
This is more natural.

Rename Sample.baseFreq to Sample.sampleRate as well.

Remove the last parameter from DecodeWav, because sampleRate can be loaded directly from the WAV file.