### PR TITLE
feat: allow setting sample length

### DIFF
--- a/piaudio/backend.go
+++ b/piaudio/backend.go
@@ -19,7 +19,10 @@ type BackendInterface interface {
 	SetSample(ch Chan, sample *Sample, offset int, delay float64)
 
 	// SetLoop schedules the loop configuration to take effect after the specified delay.
-	SetLoop(_ Chan, start int, length int, loop LoopType, delay float64)
+	//
+	// This function can also be used to limit the sample's length. Just call
+	// SetLoop with loopType = LoopNone and provide the desired length.
+	SetLoop(_ Chan, start int, length int, loopType LoopType, delay float64)
 
 	// SetPitch schedules the pitch change to take effect after the specified delay.
 	// A pitch of 1.0 plays the sample at its original speed.

--- a/piaudio/piaudio.go
+++ b/piaudio/piaudio.go
@@ -70,6 +70,9 @@ func SetSample(ch Chan, sample *Sample, offset int, delay float64) {
 
 // SetLoop schedules the loop configuration to take effect after the specified delay.
 //
+// This function can also be used to limit the sample's length. Just call
+// SetLoop with loopType = LoopNone and provide the desired length.
+//
 // Initial start is 0, length is 2_147_483_647 and loopType is LoopNone
 func SetLoop(ch Chan, start int, length int, loopType LoopType, delay float64) {
 	Backend.SetLoop(ch, start, length, loopType, delay)

--- a/piebiten/internal/audio.go
+++ b/piebiten/internal/audio.go
@@ -217,7 +217,7 @@ func (c *channel) nextSample() (float64, bool) {
 	}
 
 	pos := int(c.position)
-	if pos >= len(c.sampleData) || (c.loop.loopType == piaudio.LoopForward && pos >= c.loop.stop) {
+	if pos >= min(len(c.sampleData), c.loop.stop) {
 		// End of sample
 		if c.loop.loopType == piaudio.LoopForward {
 			c.position = float64(c.loop.start)


### PR DESCRIPTION
SetLoop can now be used to shorten a sample. Just call SetLoop(0, length, piaudio.LoopNone).