### PR TITLE
refactor: make piloop event names consistent

### DIFF
--- a/pidebug/event.go
+++ b/pidebug/event.go
@@ -8,8 +8,8 @@ import "github.com/elgopher/pi/pievent"
 type Event string
 
 const (
-	EventPaused  Event = "paused"
-	EventResumed Event = "resumed"
+	EventPause  Event = "pause"
+	EventResume Event = "resume"
 )
 
 func Target() pievent.Target[Event] {

--- a/pidebug/pidebug.go
+++ b/pidebug/pidebug.go
@@ -20,10 +20,10 @@ func SetPaused(p bool) bool {
 	prev := paused
 	paused = p
 	if !prev && p {
-		target.Publish(EventPaused)
+		target.Publish(EventPause)
 	}
 	if prev && !p {
-		target.Publish(EventResumed)
+		target.Publish(EventResume)
 	}
 	return prev
 }

--- a/piebiten/internal/ebitengame.go
+++ b/piebiten/internal/ebitengame.go
@@ -85,7 +85,7 @@ type EbitenGame struct {
 
 func (g *EbitenGame) Update() error {
 	if ebiten.IsWindowBeingClosed() {
-		piloop.Target().Publish(piloop.EventWindowClosed)
+		piloop.Target().Publish(piloop.EventWindowClose)
 		return ebiten.Termination
 	}
 
@@ -99,16 +99,16 @@ func (g *EbitenGame) Update() error {
 		if pi.Init != nil {
 			pi.Init()
 		}
-		piloop.Target().Publish(piloop.EventGameStarted)
+		piloop.Target().Publish(piloop.EventInit)
 		g.audioBackend.ebitenPlayer.Play()
 	}
 	g.started = true
 
 	if g.ebitenFrame%(ebitenTPS/pi.TPS()) == 0 {
 		if !g.paused {
-			piloop.Target().Publish(piloop.EventFrameStarted)
+			piloop.Target().Publish(piloop.EventFrameStart)
 		}
-		piloop.DebugTarget().Publish(piloop.EventFrameStarted)
+		piloop.DebugTarget().Publish(piloop.EventFrameStart)
 	}
 
 	g.updateMouse()
@@ -208,9 +208,9 @@ func (g *EbitenGame) Resize() {
 
 func (g *EbitenGame) onPidebugEvent(event pidebug.Event, _ pievent.Handler) {
 	switch event {
-	case pidebug.EventPaused:
+	case pidebug.EventPause:
 		g.paused = true
-	case pidebug.EventResumed:
+	case pidebug.EventResume:
 		g.paused = false
 	}
 }

--- a/piebiten/internal/pad.go
+++ b/piebiten/internal/pad.go
@@ -55,7 +55,7 @@ func (g *ebitenGamepads) publishDisconnectedGamepadEvents() {
 	for _, id := range g.gamepadIDs {
 		if inpututil.IsGamepadJustDisconnected(id) {
 			pipad.ConnectionTarget().Publish(pipad.EventConnection{
-				Type:   pipad.EventDisconnected,
+				Type:   pipad.EventDisconnect,
 				Player: int(id),
 			})
 		}
@@ -65,7 +65,7 @@ func (g *ebitenGamepads) publishDisconnectedGamepadEvents() {
 func (g *ebitenGamepads) publishConnectedGamepadEvents() {
 	for _, id := range g.gamepadIDs {
 		pipad.ConnectionTarget().Publish(pipad.EventConnection{
-			Type:   pipad.EventConnected,
+			Type:   pipad.EventConnect,
 			Player: int(id),
 		})
 	}

--- a/piloop/event.go
+++ b/piloop/event.go
@@ -6,11 +6,11 @@ package piloop
 type Event string
 
 const (
-	EventGameStarted  Event = "game_started"  // just before first frame
-	EventFrameStarted Event = "frame_started" // beginning of the frame
-	EventUpdate       Event = "update"        // after pi.Update
-	EventLateUpdate   Event = "late_update"   // after EventUpdate
-	EventDraw         Event = "draw"          // after pi.Draw
-	EventLateDraw     Event = "late_draw"     // after EventDraw
-	EventWindowClosed Event = "window_closed" // when user closes the window (desktop only)
+	EventInit        Event = "init"         // when the game is started, just before the first frame
+	EventFrameStart  Event = "frame_start"  // beginning of the frame
+	EventUpdate      Event = "update"       // after pi.Update
+	EventLateUpdate  Event = "late_update"  // after EventUpdate
+	EventDraw        Event = "draw"         // after pi.Draw
+	EventLateDraw    Event = "late_draw"    // after EventDraw
+	EventWindowClose Event = "window_close" // when a user closes the window (desktop only)
 )

--- a/pipad/event.go
+++ b/pipad/event.go
@@ -29,8 +29,8 @@ type EventConnection struct {
 type EventConnectionType string
 
 const (
-	EventConnected    EventConnectionType = "connected"
-	EventDisconnected EventConnectionType = "disconnected"
+	EventConnect    EventConnectionType = "connect"
+	EventDisconnect EventConnectionType = "disconnect"
 )
 
 var buttonTarget = pievent.NewTarget[EventButton]()

--- a/pipad/pipad.go
+++ b/pipad/pipad.go
@@ -127,7 +127,7 @@ func onButton(event EventButton, _ pievent.Handler) {
 var playerCount = 0
 
 func onConnection(event EventConnection, _ pievent.Handler) {
-	if event.Type == EventDisconnected {
+	if event.Type == EventDisconnect {
 		log.Println("Controller disconnected", event.Player)
 		buttonState[event.Player] = &input.State[Button]{}
 		playerCount -= 1


### PR DESCRIPTION
Standardize naming of piloop events. For example, EventGameStarted and EventUpdate had inconsistent naming styles.

Also, EventGameStarted is now aligned with the Init function from the pi package.