### PR TITLE
refactor: Rename pi.Spr to pi.DrawSprite and pi.Blit to pi.DrawCanvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ Yes — the core functionality is implemented and ready to use. Currently, the f
 
 Note: Pi does not yet have high-level APIs for music playback. However, there is a low-level [piaudio](piaudio) API that can be used to create custom packages for playing, for example, [MOD][mod] and [XM][xm] modules.
 
-### What similarities does Pi have with Pico-8 on the API level?
+### What similarities does Pi have with Pico-8/Picotron on the API level?
 
-* Many core concepts are similar: game loop, drawing sprites and shapes, printing text, clipping, camera movement, palette swapping, and handling input. Some functions even share the same names.
+* Many core concepts are similar: game loop, drawing sprites and shapes, printing text, clipping, camera movement, palette swapping, color tables, and handling input.
 * The screen resolution is small and the number of colors is limited — just like in Pico-8.  
   However, in Pi you can freely change the resolution and customize the palette.
 

--- a/_examples/audio/piano/main.go
+++ b/_examples/audio/piano/main.go
@@ -75,7 +75,7 @@ func main() {
 		}
 
 		// Draw the piano image with updated color tables
-		pi.Blit(pianoCanvas, 0, 0)
+		pi.DrawCanvas(pianoCanvas, 0, 0)
 
 		// Draw labels for each piano key
 		printLetters()

--- a/_examples/gamepad/main.go
+++ b/_examples/gamepad/main.go
@@ -32,11 +32,11 @@ func main() {
 
 	pi.Draw = func() {
 		pi.Cls()
-		pi.Blit(gamepad, 0, 0)
+		pi.DrawCanvas(gamepad, 0, 0)
 
 		for button, sprite := range buttonSprites {
 			if pipad.Duration(button) > 0 { // duration is > 0 when button is pressed
-				pi.Spr(sprite, sprite.X, sprite.Y+1) // draw pressed button
+				pi.DrawSprite(sprite, sprite.X, sprite.Y+1) // draw pressed button
 			}
 		}
 

--- a/_examples/shapes/main.go
+++ b/_examples/shapes/main.go
@@ -114,7 +114,7 @@ func main() {
 }
 
 func drawMousePointer() {
-	pi.Spr(cursorSprites[currentShapeIdx], pimouse.Position.X, pimouse.Position.Y)
+	pi.DrawSprite(cursorSprites[currentShapeIdx], pimouse.Position.X, pimouse.Position.Y)
 }
 
 func radius(x0, y0, x1, y1 int) int {

--- a/_examples/snake/main.go
+++ b/_examples/snake/main.go
@@ -138,7 +138,7 @@ func drawGrid() {
 
 func drawFruit() {
 	verticalShift := frame % 10 / 5 // simple animation
-	pi.Spr(fruitSprite, fruit.X*gridSize, fruit.Y*gridSize+verticalShift)
+	pi.DrawSprite(fruitSprite, fruit.X*gridSize, fruit.Y*gridSize+verticalShift)
 }
 
 func drawSnake() {
@@ -153,10 +153,10 @@ func drawSnake() {
 	case downDirection:
 		headSprite = headVertical.WithFlipY(true) // reuse sprite
 	}
-	pi.Spr(headSprite, snake[0].X*gridSize, snake[0].Y*gridSize)
+	pi.DrawSprite(headSprite, snake[0].X*gridSize, snake[0].Y*gridSize)
 	for i := 1; i < len(snake); i++ {
 		bodySegment := snake[i]
-		pi.Spr(bodySprite, bodySegment.X*gridSize, bodySegment.Y*gridSize)
+		pi.DrawSprite(bodySprite, bodySegment.X*gridSize, bodySegment.Y*gridSize)
 	}
 }
 

--- a/internal/bench/pi_test.go
+++ b/internal/bench/pi_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/elgopher/pi"
 )
 
-func BenchmarkSpr(b *testing.B) {
+func BenchmarkDrawSprite(b *testing.B) {
 	pi.SetScreenSize(256, 256)
 	canvas := pi.NewCanvas(256, 256)
 	for i := 0; i < canvas.W()*canvas.H(); i++ {
@@ -20,7 +20,7 @@ func BenchmarkSpr(b *testing.B) {
 	sprite := pi.SpriteFrom(canvas, 128, 128, 16, 16) //  396.6 (1 color table), 510 (4), vs 559 (ReadMask and TargetMask)
 
 	for b.Loop() {
-		pi.Spr(sprite, 10, 10)
+		pi.DrawSprite(sprite, 10, 10)
 	}
 }
 

--- a/pi.go
+++ b/pi.go
@@ -73,7 +73,7 @@ type Number interface {
 }
 
 // SetDrawTarget sets c as the target Canvas for all subsequent drawing,
-// including functions like Spr, SetPixel, Line, etc.
+// including functions like DrawSprite, SetPixel, Line, etc.
 //
 // This function also automatically sets the clip region to cover the entire area of c.
 func SetDrawTarget(c Canvas) (prev Canvas) {

--- a/pifont/pifont.go
+++ b/pifont/pifont.go
@@ -65,7 +65,7 @@ func (s Sheet) Print(str string, x, y int) (currentX, currentY int) {
 		Source: intermediateCanvas,
 	}
 	pi.SetDrawTarget(originalDrawTarget)
-	pi.Spr(coloredText, x, y)
+	pi.DrawSprite(coloredText, x, y)
 
 	// revert bgColor transparency
 	pi.ColorTables[0][bgColor] = prevBgColorTable
@@ -85,7 +85,7 @@ func (s Sheet) PrintOriginal(str string, x, y int) (maxX, currentY int) {
 			continue
 		}
 		sprite := s.Chars[r]
-		pi.Spr(sprite, currentX, currentY)
+		pi.DrawSprite(sprite, currentX, currentY)
 		currentX += sprite.W
 		maxX = max(maxX, currentX)
 	}

--- a/piscope/internal/gui.go
+++ b/piscope/internal/gui.go
@@ -86,7 +86,7 @@ func attachIconButton(parent *pigui.Element, icon pi.Sprite, x int) *IconButton 
 		}()
 		pi.Pal(0, *bgColor) // 0 is bg color in icons.png
 		pi.Pal(1, *fgColor) // 1 is fg color in icons.png
-		pi.Spr(iconBtn.Icon, 0, y)
+		pi.DrawSprite(iconBtn.Icon, 0, y)
 	}
 	return iconBtn
 }

--- a/sprite.go
+++ b/sprite.go
@@ -7,20 +7,20 @@ import (
 	"fmt"
 )
 
-// Spr draws the given sprite at (dx, dy) on the current draw target.
+// DrawSprite draws the given sprite at (dx, dy) on the current draw target.
 //
 // It takes into account the camera position, clipping region,
 // color tables, and masks.
-func Spr(sprite Sprite, dx, dy int) {
+func DrawSprite(sprite Sprite, dx, dy int) {
 	Stretch(sprite, dx, dy, sprite.W, sprite.H)
 }
 
-// Blit draws the contents of the src Canvas at (x, y) on the current draw target.
+// DrawCanvas draws the contents of the src Canvas at (x, y) on the current draw target.
 //
 // It takes into account the camera position, clipping region,
 // color tables, and masks.
-func Blit(src Canvas, x int, y int) {
-	Spr(CanvasSprite(src), x, y)
+func DrawCanvas(src Canvas, x int, y int) {
+	DrawSprite(CanvasSprite(src), x, y)
 }
 
 // CanvasSprite returns a Sprite covering the entire canvas.
@@ -41,7 +41,7 @@ func SpriteFrom(canvas Canvas, x, y, w, h int) Sprite {
 // It takes into account the camera position, clipping region,
 // color tables, and masks.
 func Stretch(sprite Sprite, dx, dy, dw, dh int) {
-	// Stretch is fast, so there is no need to implement dedicated Spr or Blit
+	// Stretch is fast, so there is no need to implement dedicated DrawSprite or DrawCanvas
 	// functions.
 	dx -= Camera.X
 	dy -= Camera.Y

--- a/surface_test.go
+++ b/surface_test.go
@@ -155,7 +155,7 @@ func BenchmarkSurface_Get(b *testing.B) {
 	}
 }
 
-func BenchmarkBlit(b *testing.B) {
+func BenchmarkDrawCanvas(b *testing.B) {
 	dst := pi.NewCanvas(320, 180)
 	pi.SetDrawTarget(dst)
 
@@ -163,7 +163,7 @@ func BenchmarkBlit(b *testing.B) {
 	src.Clear(7)
 
 	for b.Loop() {
-		pi.Blit(src, 130, 130)
+		pi.DrawCanvas(src, 130, 130)
 	}
 }
 


### PR DESCRIPTION
The name pi.Spr was unclear and primarily recognizable to Pico-8 users. The new name pi.DrawSprite better reflects its purpose: drawing a sprite.

Similarly, pi.Blit was cryptic for users unfamiliar with graphics terminology. The new name, pi.DrawCanvas, is more descriptive.