### PR TITLE
refactor: Rename pi.Pal to pi.RemapColor

### DIFF
--- a/_examples/audio/piano/main.go
+++ b/_examples/audio/piano/main.go
@@ -63,15 +63,15 @@ func main() {
 		// Map each key color to either white (tone) or black (semitone)
 		for key, color := range keyColors {
 			if slices.Contains(semitoneLetters, key) {
-				pi.Pal(color, 0)
+				pi.RemapColor(color, 0)
 			} else {
-				pi.Pal(color, 7)
+				pi.RemapColor(color, 7)
 			}
 		}
 
 		// Highlight the last pressed key in gray
 		if selectedKey != "" {
-			pi.Pal(keyColors[selectedKey], 6)
+			pi.RemapColor(keyColors[selectedKey], 6)
 		}
 
 		// Draw the piano image with updated color tables

--- a/colortable.go
+++ b/colortable.go
@@ -53,8 +53,20 @@ func ResetColorTables() {
 	ColorTables[1] = identityColorTable
 }
 
-func Pal(fromColor, toColor Color) {
-	ColorTables[0][fromColor] = opaqueColorTable[toColor]
+// RemapColor changes how the color from is rendered by replacing it with the color to.
+//
+// This affects all future drawing operations (sprites, shapes, text, etc.).
+// It does not modify the original image or sprite data — only how colors appear on screen.
+//
+// For example, calling:
+//
+//	RemapColor(1, 15)
+//
+// causes all pixels with color index 1 to be drawn using color 15 instead.
+//
+// This function updates the color tables. To reset the changes, use ResetColorTables.
+func RemapColor(from, to Color) {
+	ColorTables[0][from] = opaqueColorTable[to]
 }
 
 func Palt(color Color, t bool) {

--- a/pifont/pifont.go
+++ b/pifont/pifont.go
@@ -39,8 +39,8 @@ func (s Sheet) Print(str string, x, y int) (currentX, currentY int) {
 	// create fake bg color to avoid a situation when fg and bg colors are the same
 	bgColor := (currentColor + 1) % pi.MaxColors
 	intermediateCanvas.Clear(s.BgColor)
-	pi.Pal(s.FgColor, currentColor)
-	pi.Pal(s.BgColor, bgColor)
+	pi.RemapColor(s.FgColor, currentColor)
+	pi.RemapColor(s.BgColor, bgColor)
 	pi.SetDrawTarget(intermediateCanvas)
 
 	// first draw text in selected color on intermediateCanvas

--- a/piscope/internal/gui.go
+++ b/piscope/internal/gui.go
@@ -84,8 +84,8 @@ func attachIconButton(parent *pigui.Element, icon pi.Sprite, x int) *IconButton 
 		defer func() {
 			pi.ColorTables[0] = prevColorTable
 		}()
-		pi.Pal(0, *bgColor) // 0 is bg color in icons.png
-		pi.Pal(1, *fgColor) // 1 is fg color in icons.png
+		pi.RemapColor(0, *bgColor) // 0 is bg color in icons.png
+		pi.RemapColor(1, *fgColor) // 1 is fg color in icons.png
 		pi.DrawSprite(iconBtn.Icon, 0, y)
 	}
 	return iconBtn


### PR DESCRIPTION
The name pi.Pal was unclear and primarily recognizable to Pico-8 users. The new name, pi.RemapColor, better reflects its purpose: remapping one color to another.
