### PR TITLE
refactor: Rename pi.Palt to pi.SetTransparency

### DIFF
--- a/_examples/audio/piano/main.go
+++ b/_examples/audio/piano/main.go
@@ -35,7 +35,7 @@ func main() {
 	pianoCanvas := pi.DecodeCanvas(pianoPNG)
 
 	pi.SetScreenSize(113, 46)
-	pi.Palt(0, false) // disable transparency for color 0
+	pi.SetTransparency(0, false) // disable transparency for color 0
 
 	pi.Init = func() {
 		// The sample must be loaded before use,

--- a/colortable.go
+++ b/colortable.go
@@ -69,7 +69,22 @@ func RemapColor(from, to Color) {
 	ColorTables[0][from] = opaqueColorTable[to]
 }
 
-func Palt(color Color, t bool) {
+// SetTransparency sets whether the given color is treated as transparent.
+//
+// When transparency is enabled for a color, pixels using that color will not be drawn.
+// This affects all future drawing operations (sprites, shapes, text, etc.).
+// It does not modify the original image or sprite data — only how colors appear on screen.
+//
+// For example, calling:
+//
+//	SetTransparency(0, true)
+//
+// makes color 0 transparent, meaning all pixels with color index 0 will be skipped during drawing.
+//
+// To disable transparency for a color, pass false as the second argument.
+//
+// This function updates the color tables. To reset the changes, use ResetColorTables.
+func SetTransparency(color Color, t bool) {
 	if t {
 		ColorTables[0][color] = transparentColor
 	} else {

--- a/pifont/pifont.go
+++ b/pifont/pifont.go
@@ -52,7 +52,7 @@ func (s Sheet) Print(str string, x, y int) (currentX, currentY int) {
 
 	// make bgColor transparent
 	prevBgColorTable = pi.ColorTables[0][bgColor]
-	pi.Palt(bgColor, true)
+	pi.SetTransparency(bgColor, true)
 
 	// now copy text in target color on original draw target
 	coloredText := pi.Sprite{

--- a/pifont/pifont_test.go
+++ b/pifont/pifont_test.go
@@ -91,7 +91,7 @@ func TestSheet_Print(t *testing.T) {
 
 				pi.Screen().Clear(testCase.bgColor)
 				pi.SetColor(testCase.textColor)
-				pi.Palt(testCase.textColor, false)
+				pi.SetTransparency(testCase.textColor, false)
 				// when
 				fontSheet.Print("S", 0, 0)
 				// then


### PR DESCRIPTION
The name pi.Palt was unclear and primarily recognizable to Pico-8 users. The new name, pi.SetTransparency, better reflects its purpose: enabling or disabling transparency for a specific color.
