### PR TITLE
refactor: Rename pikey.Control to pikey.Ctrl

### DIFF
--- a/piebiten/internal/input/keyboard.go
+++ b/piebiten/internal/input/keyboard.go
@@ -150,7 +150,7 @@ var keyMap = map[ebiten.Key]pikey.Key{
 	ebiten.KeySpace:          pikey.Space,
 	ebiten.KeyTab:            pikey.Tab,
 	ebiten.KeyAlt:            pikey.Alt,
-	ebiten.KeyControl:        pikey.Control,
+	ebiten.KeyControl:        pikey.Ctrl,
 	ebiten.KeyShift:          pikey.Shift,
 	ebiten.KeyMeta:           "Meta",
 }

--- a/pikey/pikey.go
+++ b/pikey/pikey.go
@@ -111,9 +111,9 @@ const (
 	Slash        Key = "/"
 	Space        Key = " "
 	Tab          Key = "Tab"
-	Alt          Key = "Alt"     // alt left or right
-	Control      Key = "Control" // control left or right
-	Shift        Key = "Shift"   // shift left or right
+	Alt          Key = "Alt"   // alt left or right (virtual key)
+	Ctrl         Key = "Ctrl"  // ctrl left or right (virtual key)
+	Shift        Key = "Shift" // shift left or right (virtual key)
 )
 
 var target = pievent.NewTarget[Event]()

--- a/piscope/internal/input.go
+++ b/piscope/internal/input.go
@@ -31,7 +31,7 @@ func registerShortcuts() {
 			exitConsoleMode()
 		}
 	}
-	pikey.RegisterShortcut(onCtrlShiftI, pikey.Control, pikey.Shift, pikey.I)
+	pikey.RegisterShortcut(onCtrlShiftI, pikey.Ctrl, pikey.Shift, pikey.I)
 
 	// F12
 	f12Down := pikey.Event{Type: pikey.EventDown, Key: pikey.F12}


### PR DESCRIPTION
To be consistent with pikey.CtrlLeft and pikey.CtrlRight