### PR TITLE
performance: Speed up piaudio.ClearChan()

### DIFF
--- a/_examples/audio/lowlevel/main.go
+++ b/_examples/audio/lowlevel/main.go
@@ -9,13 +9,14 @@ package main
 
 import (
 	_ "embed"
+	"log"
+
 	"github.com/elgopher/pi"
 	"github.com/elgopher/pi/piaudio"
 	"github.com/elgopher/pi/piebiten"
 	"github.com/elgopher/pi/pievent"
 	"github.com/elgopher/pi/piloop"
 	"github.com/elgopher/pi/pimouse"
-	"log"
 )
 
 //go:embed "wave.wav"

--- a/_examples/audio/piano/main.go
+++ b/_examples/audio/piano/main.go
@@ -8,13 +8,14 @@ package main
 
 import (
 	_ "embed"
+	"math"
+	"slices"
+
 	"github.com/elgopher/pi"
 	"github.com/elgopher/pi/piaudio"
 	"github.com/elgopher/pi/picofont"
 	"github.com/elgopher/pi/piebiten"
 	"github.com/elgopher/pi/pikey"
-	"math"
-	"slices"
 )
 
 var (


### PR DESCRIPTION
Improve the performance of piebiten's ClearChan() command. Before the change the complexity of command was O(n^2) in the worst case. Now it is O(n).