### PR TITLE
fix: add explanation to example

### DIFF
--- a/_examples/audio/lowlevel/main.go
+++ b/_examples/audio/lowlevel/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/elgopher/pi"
 	"github.com/elgopher/pi/piaudio"
+	"github.com/elgopher/pi/picofont"
 	"github.com/elgopher/pi/piebiten"
 	"github.com/elgopher/pi/pievent"
 	"github.com/elgopher/pi/piloop"
@@ -24,6 +25,8 @@ var clickWav []byte
 
 func main() {
 	sample := piaudio.DecodeWav(clickWav)
+
+	picofont.Print("PRESS LEFT MOUSE BUTTON TO PLAY SFX", 90, 80)
 
 	pi.Init = func() {
 		// The sample must be loaded before use,


### PR DESCRIPTION
At the moment the example screen is black, and user does not know what he is supposed to do.  Add instruction what user action will trigger playing the sound effect.